### PR TITLE
Add Code2Skill v1.1.3 to Skills

### DIFF
--- a/plugins/skills.md
+++ b/plugins/skills.md
@@ -15,6 +15,7 @@
 - [dsh-plugin-codex-bridge](https://github.com/YYTbit/dsh-plugin-codex-bridge) — 把 Codex skills/config 桥接进 DSH ⭐2 · `dsh plugin add dsh-plugin-codex-bridge`
 - [dsh-plugin-opencode-bridge](https://github.com/YYTbit/dsh-plugin-opencode-bridge) — 把 OpenCode skills/config 桥接进 DSH ⭐2 · `dsh plugin add dsh-plugin-opencode-bridge`
 - [dsh-plugin-pi-bridge](https://github.com/YYTbit/dsh-plugin-pi-bridge) — 把 pi skills/config 桥接进 DSH ⭐2 · `dsh plugin add dsh-plugin-pi-bridge`
+- [Code2Skill](https://github.com/leechen298/Code2Skill) — 从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发 · `dsh plugin add github:leechen298/Code2Skill#v1.1.3`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
## 变更

在 `plugins/skills.md` 中新增 Code2Skill，附上可复现的 v1.1.3 DSH 安装命令。

## 收录理由

Code2Skill 可从已有代码生成 Function、MCP、Agent Skill 和离线测试包；v1.1.3 已提供根级 `dsh.bundle` manifest 与 `cordis.patch.yml`，可作为 DeepSeek Harness Bundle 安装。仓库公开、采用 MIT 许可证，并已添加 `dsh-plugin` topic。

Release: https://github.com/leechen298/Code2Skill/releases/tag/v1.1.3

## 验证

- [x] 提交前已在仓库、历史 PR 和 Issue 中查重
- [x] 分类符合 `docs/taxonomy.md` 的 Skills 边界
- [x] `node scripts/gen-readme.mjs` 成功，README 折叠区共解析 288 条
- [x] `node scripts/gen-index.mjs` 成功，总索引共解析 288 条
- [x] `git diff --check` 通过
- [x] PR 仅提交贡献指南要求的 `plugins/skills.md` 源文件