### PR TITLE
Add dsh-reverse-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Three ways to use this directory:
 3. **Consume programmatically** — read [`data/plugins.json`](data/plugins.json) (334 structured entries; field docs in [data/README.md](data/README.md)).
 
 ## 🔥 Hot Plugins
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 
 Top community plugins by GitHub stars (snapshot 2026-08):
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -42,6 +42,7 @@
 3. **机器消费**：直接读 [`data/plugins.json`](data/plugins.json)（334 条结构化数据，字段说明见 [data/README.md](data/README.md)）。
 
 ## 🔥 热门插件
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究的技能路由包。
 
 按 GitHub star 排序的社区热门（数据快照 2026-08）：
 


### PR DESCRIPTION
Add **dhicoc/dsh-reverse-skill**.

Complete reverse-skill pack (85 `SKILL.md` from upstream `zhaoxuya520/reverse-skill`, MIT) packaged as a DeepSeek Harness Cordis plugin. Declares a `dsh.bundle` manifest (`cordis.patch.yml`), installable via `dsh plugin add github:dhicoc/dsh-reverse-skill`. Covers reverse engineering, authorized pentesting, security research and 42 CTF-track skills. Repo carries the `dsh-plugin` topic.