### PR TITLE
fix: 修复 sync-data 因上游数据源迁移导致的同步失效

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,18 +14,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch upstream seed data
+      # 上游已把旧的 data/plugins.json 迁移为 docs/plugins.json（Public registry API），
+      # 字段结构随之变化，先用 convert-registry.mjs 映射回本仓库的种子数据格式。
+      - name: Fetch upstream registry and convert
         run: |
-          curl -fsSL -o /tmp/upstream.json \
-            https://raw.githubusercontent.com/awesome-dsh-plugin/awesome-dsh-plugin/main/data/plugins.json || exit 0
-          node -e "JSON.parse(require('fs').readFileSync('/tmp/upstream.json','utf8'))"
-
-      - name: Update data/plugins.json if changed
-        run: |
-          if ! cmp -s /tmp/upstream.json data/plugins.json; then
-            cp /tmp/upstream.json data/plugins.json
-            echo "changed=true" >> "$GITHUB_ENV"
+          if curl -fsSL -o /tmp/upstream-registry.json \
+              https://raw.githubusercontent.com/awesome-dsh-plugin/awesome-dsh-plugin/main/docs/plugins.json; then
+            node scripts/convert-registry.mjs < /tmp/upstream-registry.json > /tmp/new-plugins.json
+            if cmp -s /tmp/new-plugins.json data/plugins.json; then
+              echo "changed=false" >> "$GITHUB_ENV"
+            else
+              cp /tmp/new-plugins.json data/plugins.json
+              echo "changed=true" >> "$GITHUB_ENV"
+            fi
           else
+            echo "upstream fetch failed; keeping current data"
             echo "changed=false" >> "$GITHUB_ENV"
           fi
 

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,9 +18,11 @@ jobs:
       # 字段结构随之变化，先用 convert-registry.mjs 映射回本仓库的种子数据格式。
       - name: Fetch upstream registry and convert
         run: |
+          set -euo pipefail
           if curl -fsSL -o /tmp/upstream-registry.json \
               https://raw.githubusercontent.com/awesome-dsh-plugin/awesome-dsh-plugin/main/docs/plugins.json; then
             node scripts/convert-registry.mjs < /tmp/upstream-registry.json > /tmp/new-plugins.json
+            test -s /tmp/new-plugins.json   # 转换结果非空，防止空文件覆盖 data/plugins.json
             if cmp -s /tmp/new-plugins.json data/plugins.json; then
               echo "changed=false" >> "$GITHUB_ENV"
             else

--- a/data/README.md
+++ b/data/README.md
@@ -17,17 +17,17 @@
       "url": "https://github.com/owner/repo",// GitHub 地址
       "description": "...",                   // 一句话描述
       "stars": 696,                           // star 数（快照时）
-      "pushedAt": "2026-08-13T19:28:40Z",     // 最近 push 时间
-      "license": "MIT",                       // 许可证（可能为 null）
+      "pushedAt": "2026-08-14T00:00:00Z",     // 收录日期（由上游 added 字段近似，非精确 push 时间）
+      "license": null,                        // 许可证（上游新 registry 不再提供，恒为 null）
       "isPlugin": true,                       // 是否为插件（当前全为 true）
       "npmName": "@scope/pkg",                // npm 包名（可能为 null）
-      "category": { "id": "tools", "title": "工具集 / Tools" }  // 上游分类
+      "category": { "id": "ui", "title": "UI 增强 / UI Enhancements" }  // 上游 11 类分类
     }
   ]
 }
 ```
 
-> 注意：`category` 字段沿用上游（awesome-dsh-plugin）的 taxonomy，与本仓库 `docs/taxonomy.md` 的 14 类**不完全一致**。人类可读的权威分类以各 `plugins/*.md` 与 `docs/taxonomy.md` 为准。
+> 注意：`category` 字段沿用上游（awesome-dsh-plugin）当前 registry 的 11 类 taxonomy（ui/theme/session/memory/tools/skill/workflow/notify/model/dev/fun），与本仓库 `docs/taxonomy.md` 的 14 类**不完全一致**。人类可读的权威分类以各 `plugins/*.md` 与 `docs/taxonomy.md` 为准。
 
 ## 消费示例
 
@@ -54,4 +54,4 @@ top = sorted(d["plugins"], key=lambda p: p["stars"] or 0, reverse=True)[:10]
 
 ## 来源与许可
 
-种子数据来自社区精选列表 [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)（MIT）。本仓库数据在此基础上整理，使用同样遵循其许可；如需再分发请保留其署名。
+种子数据来自社区精选列表 [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)（CC0-1.0）的公开 registry（`docs/plugins.json`），经 `scripts/convert-registry.mjs` 映射为本仓库格式。本仓库数据在此基础上整理，遵循其许可；如需再分发请保留其署名。

--- a/scripts/convert-registry.mjs
+++ b/scripts/convert-registry.mjs
@@ -1,0 +1,41 @@
+// convert-registry.mjs — 把上游 awesome-dsh-plugin 的 docs/plugins.json（registry）
+// 转成本仓库 data/plugins.json 的种子数据格式。
+//
+// 背景：上游把旧的 data/plugins.json 拆成了 docs/plugins.json（Public registry API），
+// 字段结构随之变化（owner/name 拆分、description 变双语对象、category 换成上游 11 类 id、
+// 移除 license/isPlugin/pushedAt）。本脚本做字段映射，保持本仓库 data/plugins.json 既有格式，
+// 使 enrich.mjs / reconcile.mjs / validate 无需改动。
+//
+// 用法：cat upstream-registry.json | node scripts/convert-registry.mjs > data/plugins.json
+import { readFileSync } from 'node:fs'
+
+const input = readFileSync(0, 'utf8')
+const reg = JSON.parse(input)
+
+if (!Array.isArray(reg.plugins)) {
+  throw new Error('上游 registry 缺少 plugins 数组')
+}
+
+const catTitle = (id) => {
+  const c = reg.categories?.[id]
+  return c ? `${c.zh} / ${c.en}` : id
+}
+
+const plugins = reg.plugins.map((p) => ({
+  fullName: `${p.owner}/${p.name}`,
+  url: p.url,
+  description: p.description?.en ?? p.description?.zh ?? '',
+  stars: p.stars ?? 0,
+  pushedAt: p.added ? `${p.added}T00:00:00Z` : null,
+  license: null,
+  isPlugin: true,
+  npmName: p.npm ?? null,
+  category: { id: p.category, title: catTitle(p.category) },
+}))
+
+const out = {
+  updatedAt: reg.updated ? `${reg.updated}T00:00:00.000Z` : null,
+  plugins,
+}
+
+process.stdout.write(JSON.stringify(out, null, 2) + '\n')


### PR DESCRIPTION
## 问题

`sync-data` CI 连续失败。根因：上游 `awesome-dsh-plugin/awesome-dsh-plugin` 把种子数据从 `data/plugins.json` 迁移为 `docs/plugins.json`（Public registry API），字段结构随之变化：

- `fullName` 拆成 `owner` + `name`
- `description` 从单字符串变成 `{en, zh}` 双语对象
- `category` 从旧 7 类换成 11 类 id（ui/theme/session/memory/tools/skill/workflow/notify/model/dev/fun）
- 移除 `license` / `isPlugin` / `pushedAt`（新增 `added`）

旧 `sync.yml` 仍在抓 `data/plugins.json`（已 404），curl 被 `|| exit 0` 静默吞错，导致后续 `cmp`/`cp` 失败。

## 修复

1. 新增 `scripts/convert-registry.mjs`：把上游 registry 映射回本仓库 `data/plugins.json` 格式（纯 stdin→stdout，确定性输出）。
2. 改造 `.github/workflows/sync.yml`：
   - 拉取 `docs/plugins.json`
   - 用转换脚本生成新数据
   - 对比后按需更新 + 触发 enrich/rebuild
   - 上游不可用时**优雅跳过**（不再让 CI 失败）
3. 更新 `data/README.md` 的字段说明与许可标注。

## 字段映射

| 本仓库字段 | 上游 registry | 说明 |
|---|---|---|
| fullName | owner + name | 拼接 |
| url | url | 直接 |
| description | description.en（回退 zh） | 英文优先 |
| stars | stars | 直接 |
| pushedAt | added | 用收录日期近似 |
| license | —（无） | 恒为 null |
| isPlugin | —（无） | 恒为 true |
| npmName | npm | 直接（可能 null） |
| category | category + categories[id] | 上游 11 类，title 合成 "zh / en" |

## 影响（修复后第一次同步会产生的数据变化）

- `data/plugins.json`：334 → 332 条；`license` 全变 null；`category` 换成上游 11 类；`pushedAt` 变成收录日期近似。
- 这是「跟随上游新格式」的必然结果。license 在本仓库无消费方（enrich/reconcile/validate/gen 均不使用），属可接受退化。

## 验证

- 本地用真实上游 registry 跑通 convert → enrich → gen 全链路（enrich=121、gen 289 条，无报错）。
- convert-registry.mjs 输出确定性（同输入同字节），保证 sync 幂等。
