### PR TITLE
收录 dsh-plugin-open-app（界面增强 / 面板）

### DIFF
--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -41,6 +41,7 @@
 - [dsh-token-usage](https://github.com/hashdiana/dsh-token-usage) — 更美观的 Token 用量条：上下文占用/输入输出/缓存分解/首字延迟 ⭐2 · `dsh plugin add dsh-token-usage`
 - [dsh-model-config-sync](https://github.com/LiangYin233/dsh-provider-model-configurator) — 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 ⭐11 · `dsh plugin add dsh-model-config-sync`
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) — DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 ⭐2652 · `dsh plugin add dsh-web-ui`
+- [dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) — 把 open-mcp-apps 带进 DSH：每个 MCP app 一个侧边栏容器（独立 workspace + 会话 + App mode），带 agent 状态条、聊天内行内渲染与 App Store · `dsh plugin --profile web add @2nd1st/dsh-plugin-open-app`
 
 ## 生成式 UI / 组件
 


### PR DESCRIPTION
在 `plugins/ui-themes.md` 的「界面增强 / 面板」下新增一行。

**是什么**：把 [open-mcp-apps](https://github.com/2nd1st/open-mcp-apps)（MCP Apps 引擎）带进 DeepSeek Harness。每个 MCP app 在侧边栏里是自己的容器——独立的 workspace、独立的会话、独立的 App mode 系统提示；app UI 下面是一条 agent 状态条（正在调什么工具、是否在等你、是否失败）；普通聊天里模型调 `open_app` 时，工具卡直接变成运行中的 app。另有 App Store 节点。

**为什么放这一类**：它加的是侧边栏区块、Tab 面板和状态条，和 DSH-better-sidebar / dsh-task-status 是同类；MIT，npm 已发布 `0.1.0`。

**装法**：`dsh plugin add dsh-plugin-open-app`，然后在 profile 的 `cordis.patch.yml` 里 insert 一行 `dsh-plugin-open-app`（README 有完整三步）。

提交前已 grep 确认目录里尚未收录。dsh 与本插件都处于 `0.1.0` 开发者预览阶段，如需标注早期请告知，我照改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
