### PR TITLE
feat: 完善目录数据——补全元数据、改名/死仓库修正、validate 加强、补录候选

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,12 +14,5 @@ jobs:
         with:
           node-version: 20
 
-      - name: Validate data/plugins.json
-        run: |
-          node -e "
-            const d = require('./data/plugins.json');
-            if (!Array.isArray(d.plugins)) throw new Error('plugins must be an array');
-            const missing = d.plugins.filter(p => !p.fullName || !p.url).length;
-            if (missing) throw new Error(missing + ' entries missing fullName/url');
-            console.log('OK: plugins =', d.plugins.length);
-          "
+      - name: Validate data & directory
+        run: node scripts/validate.mjs

--- a/INDEX.md
+++ b/INDEX.md
@@ -1,6 +1,6 @@
 # 插件总索引
 
-> 全部插件单文件扁平清单（按分类分组），方便在仓库里 `Ctrl+F` 全局搜索。共 **301** 条。
+> 全部插件单文件扁平清单（按分类分组），方便在仓库里 `Ctrl+F` 全局搜索。共 **305** 条。
 >
 > 返回：[README](README.md) · [中文](README.zh.md)
 
@@ -23,9 +23,9 @@
 | [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化 test_run：自动探测 vitest/jest/pytest/node:test 并解析失败摘要 | 2 | `dsh plugin add dsh-test-runner` |
 | [dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | 密钥/危险模式扫描（API key/token/私钥脱敏，零依赖） | 1 | `dsh plugin add dsh-security-scan` |
 | [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) | 按 agent 的按需工具发现 + 渐进式 schema 披露 | 2 | `dsh plugin add @deepseek-ai/dsh-tool-search` |
-| [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) | 用 Monaco 编辑器创建/管理沙箱化自定义 JS 工具 | 23 | `dsh plugin add dsh-custom-tool` |
+| [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) | 用 Monaco 编辑器创建/管理沙箱化自定义 JS 工具 | 24 | `dsh plugin add dsh-custom-tool` |
 | [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) | 自动识别并解码 Bash 输出编码（UTF-16LE/UTF-8/GBK），修中文乱码 | 7 |  |
-| [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | Codex 风格 `@file` 文件引用，输入框里直接搜索并引用工作区文件 | 187 | `dsh plugin add dsh-at-file` |
+| [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | Codex 风格 `@file` 文件引用，输入框里直接搜索并引用工作区文件 | 198 | `dsh plugin add dsh-at-file` |
 | [dsh-wikilink](https://github.com/zhaoscsc/dsh-wikilink) | Obsidian 风格 `[[wikilink]]` 提及：模糊搜索笔记标题并附加内容 | 3 | `dsh plugin add dsh-wikilink` |
 | [dsh-safe-delete](https://github.com/Qintsg/dsh-safe-delete) | 安全删除：移入回收站/暂存区而非永久删除，支持恢复 | 3 |  |
 | [dsh-bisect-debug](https://github.com/PangYiMing/dsh-bisect-debug) | 二分法定位 bug 根因（代码/边界/commit） | 1 | `dsh plugin add dsh-bisect-debug` |
@@ -33,8 +33,8 @@
 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | 让 AI 帮你连数据库、写 SQL | 25 | `dsh plugin add @deepseek-ai/dsh-data-agent` |
 | [dsh-openapi](https://github.com/Degurechaff57/dsh-openapi) | Safe OpenAPI 3.x 发现与 API 调用工具 | 4 | `dsh plugin add dsh-openapi` |
 | [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) | 暴露 run_python / run_node 工具，可配置解释器路径 | 6 | `dsh plugin add @huanlin/dsh-plugin-interpreters` |
-| [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) | doc_read/doc_write：以有界、单元格寻址方式读写 xlsx/pdf/docx/pptx/ipynb | 2 |  |
-| [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) | 向模型暴露 MineRU 文档解析工具 | 18 | `dsh plugin add @huanlin/dsh-plugin-mineru` |
+| [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) | doc_read/doc_write：以有界、单元格寻址方式读写 xlsx/pdf/docx/pptx/ipynb | 3 |  |
+| [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) | 向模型暴露 MineRU 文档解析工具 | 20 | `dsh plugin add @huanlin/dsh-plugin-mineru` |
 | [dsh-plugin-sleep](https://github.com/HuanLinOTO/dsh-plugin-sleep) | 暴露单个 `sleep` 工具，让模型按需暂停（支持取消） | 6 | `dsh plugin add @huanlin/dsh-plugin-sleep` |
 | [dsh-port-guard](https://github.com/PangYiMing/dsh-port-guard) | 端口占用处置（复用/切换/精确 kill） | 1 | `dsh plugin add dsh-port-guard` |
 | [dsh-scout](https://github.com/omdsh-dev/dsh-scout) | 只读环境探测：运行环境/版本/资源/端口/服务/硬件/工作区 | 2 | `dsh plugin add @deepseek-ai/dsh-tool-scout` |
@@ -49,18 +49,19 @@
 | [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) | 把已有 Agent Skills（Claude/Codex/Cursor/Gemini 的 SKILL.md）带进 DSH，渐进式索引 + 按需加载 | 2 | `dsh plugin add @dsh-skillport/bundle` |
 | [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) | 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索/安装/生命周期管理 | 2 | `dsh plugin add dsh-find-skill` |
 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | 构建与测试 DSH 插件的 Agent 技能（脚手架到测试分层） | 7 |  |
-| [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | 五阶段「书→技能」长任务（抓取→解析→理解→生成→安装）+ 3 个人工关卡 | 3 | `dsh plugin add dsh-book2skill` |
+| [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | 五阶段「书→技能」长任务（抓取→解析→理解→生成→安装）+ 3 个人工关卡 | 4 | `dsh plugin add dsh-book2skill` |
 | [dsh-superpowers](https://github.com/codeAnqiang-ma/dsh-superpowers) | Superpowers（obra/superpowers）作为 DSH 插件：方法论技能 + 会话引导 | 3 | `dsh plugin add dsh-superpowers` |
 | [dsh-plugin-code-review](https://github.com/YYTbit/dsh-plugin-code-review) | 结构化代码审查技能（YYTbit 系列） | 1 | `dsh plugin add dsh-plugin-code-review` |
 | [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) | 增量 diff 审查：checkpoint 队列 + Web 面板 + 审查意见注入 agent | 2 | `dsh plugin add @dsh-plugin/dsh-review-loop` |
-| [dsh-skill-manager](https://github.com/bitterSmilezzz/dsh-skill-manager) | 在 Web 设置页管理（列出/禁用启用/编辑）skills | 1 | `dsh plugin add dsh-skill-manager` |
+| [dsh-skill-manager](https://github.com/bitterSmilezzz/dsh-skill-manager) | 在 Web 设置页管理（列出/禁用启用/编辑）skills（已删除） | 1 | `dsh plugin add dsh-skill-manager` |
 | [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) | 把 Claude Code 记忆/技能/配置桥接进 DSH | 5 | `dsh plugin add dsh-plugin-claude-bridge` |
 | [dsh-plugin-codex-bridge](https://github.com/YYTbit/dsh-plugin-codex-bridge) | 把 Codex skills/config 桥接进 DSH | 2 | `dsh plugin add dsh-plugin-codex-bridge` |
 | [dsh-plugin-opencode-bridge](https://github.com/YYTbit/dsh-plugin-opencode-bridge) | 把 OpenCode skills/config 桥接进 DSH | 3 | `dsh plugin add dsh-plugin-opencode-bridge` |
 | [dsh-plugin-pi-bridge](https://github.com/YYTbit/dsh-plugin-pi-bridge) | 把 pi skills/config 桥接进 DSH | 2 | `dsh plugin add dsh-plugin-pi-bridge` |
 | [Code2Skill](https://github.com/leechen298/Code2Skill) | 从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发 | 2 | `dsh plugin add github:leechen298/Code2Skill#v1.1.3` |
-| [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） | 13 | `dsh plugin add github:dhicoc/dsh-reverse-skill` |
-| [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) | 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill | 84 | `dsh plugin add github:Nagi-ovo/dsh-find-plugins` |
+| [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） | 12 | `dsh plugin add github:dhicoc/dsh-reverse-skill` |
+| [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) | 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill | 89 | `dsh plugin add github:Nagi-ovo/dsh-find-plugins` |
+| [forkprobe](https://github.com/Jayden-X-L/forkprobe) | 同一任务对比多个 skill 并选出最优 | 66 | `dsh plugin add github:Jayden-X-L/forkprobe` |
 
 [↩ 回到 🧩 技能类 Skills 分类页](skills.md)
 
@@ -85,7 +86,7 @@
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
 | [dsh-skins](https://github.com/Moeblack/dsh-skins) | Web UI 皮肤合集（含 harbor 夕港黄昏皮肤） | 3 | `dsh plugin add @dsh-external/dsh-web-skins` |
-| [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | DSH Web 鲸鱼娘皮肤系列（深海女仆工坊） | 802 |  |
+| [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | DSH Web 鲸鱼娘皮肤系列（深海女仆工坊） | 834 |  |
 | [dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) | QQ2006 复古皮肤 | 10 |  |
 | [dsh-miku-skin](https://github.com/stushansusu/dsh-miku-skin) | 初音未来主题（蓝紫渐变/毛玻璃/亮暗双主题） | 2 | `dsh plugin add @deepseek-ai/dsh-client-ui-skin-miku` |
 | [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) | 模仿 Excel 的皮肤 | 8 |  |
@@ -95,31 +96,31 @@
 | [dsh-web-background](https://github.com/BruceWu1126/dsh-web-background) | Web UI 背景自定义 | 2 |  |
 | [dsh-plugin-background](https://github.com/gameswu/dsh-plugin-background) | Web UI 壁纸自定义 | 8 |  |
 | [dsh-chat-width](https://github.com/chen-001/dsh-chat-width) | 调整回复宽度（终端宽度感知） | 3 |  |
-| [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) | 换肤系统：21 套内置皮肤 + 一图生成整套配色 | 33 |  |
-| [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 988 | `dsh plugin add dsh-better-sidebar` |
+| [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) | 换肤系统：21 套内置皮肤 + 一图生成整套配色 | 34 |  |
+| [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 1065 | `dsh plugin add dsh-better-sidebar` |
 | [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) | 侧边栏集成文件浏览器、终端和 Git 审查 | 16 | `dsh plugin add @dsh-external/dsh-side-panel` |
 | [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) | 「聚焦会话」精简视图，只关注最终产出结果 | 16 | `dsh plugin add @dingyi222666/dsh-focus-chat` |
-| [ui-status-label](https://github.com/alingalingling/ui-status-label) | 把鲸鱼娘思考时的 "deep diving" 状态文案自定义 | 31 | `dsh plugin add dsh-ui-status-label` |
-| [dsh-navbar](https://github.com/vlln/dsh-navbar) | 对话节点导航条，右缘节点串快速跳转 user 消息 | 22 | `dsh plugin add @dsh-external/dsh-navbar` |
-| [dsh-task-status](https://github.com/vlln/dsh-task-status) | 后台任务状态条：对话页任务进度 + 实时输出 tail | 9 | `dsh plugin add @dsh-external/dsh-task-status` |
+| [ui-status-label](https://github.com/alingalingling/ui-status-label) | 把鲸鱼娘思考时的 "deep diving" 状态文案自定义 | 32 | `dsh plugin add dsh-ui-status-label` |
+| [dsh-navbar](https://github.com/vlln/dsh-navbar) | 对话节点导航条，右缘节点串快速跳转 user 消息 | 23 | `dsh plugin add @dsh-external/dsh-navbar` |
+| [dsh-task-status](https://github.com/vlln/dsh-task-status) | 后台任务状态条：对话页任务进度 + 实时输出 tail | 10 | `dsh plugin add @dsh-external/dsh-task-status` |
 | [dsh-web-archive](https://github.com/renat3u/dsh-web-archive) | 折叠对话中的 Think、Bash 等「无用消息」 | 7 | `dsh plugin add dsh-web-archive` |
 | [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) | 会话里程碑导航条：像 Git 提交图定位每条提问 | 14 | `dsh plugin add dsh-milestone` |
 | [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) | 键盘优先的命令面板（command palette） | 5 | `dsh plugin add @dsh-external/dsh-spotlight` |
 | [dsh-deeplink](https://github.com/qyw233/dsh-deeplink) | `?session=` / `?workspace=` 深链直达指定项目对话 | 1 | `dsh plugin add @dsh-community/dsh-deeplink` |
-| [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) | PiUI 风格 diff 查看器，替换 write/edit 的默认 DiffBlock | 11 | `dsh plugin add @dsh-external/dsh-diff-viewer` |
+| [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) | PiUI 风格 diff 查看器，替换 write/edit 的默认 DiffBlock | 12 | `dsh plugin add @dsh-external/dsh-diff-viewer` |
 | [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) | 跨平台文件拖拽与原始路径插入，无需复制文件 | 7 | `dsh plugin add @bill9109/dsh-drag-and-drop` |
 | [ex-setting](https://github.com/omdsh-dev/ex-setting) | DSH 的设置扩展 | 2 | `dsh plugin add @deepseek-ai/dsh-ex-setting` |
-| [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | 选中文字→批注→回车随消息发送，回复按批注逐条对照 | 48 | `dsh plugin add @omdsh-dev/dsh-annotation` |
+| [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | 选中文字→批注→回车随消息发送，回复按批注逐条对照 | 50 | `dsh plugin add @omdsh-dev/dsh-annotation` |
 | [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) | 带实时预览的用户/内置 system prompt 分节编辑器 | 2 | `dsh plugin add dsh-prompt-studio` |
 | [dsh-prompt-persona](https://github.com/Xilin3/dsh-prompt-persona) | 从设置页编辑系统提示词（deployment persona），带实时预览 | 4 | `dsh plugin add @xilin3/dsh-prompt-persona` |
-| [dsh-model-selector](https://github.com/bitterSmilezzz/dsh-model-selector) | provider 分组折叠 + 名称搜索的模型选择器增强 | 1 | `dsh plugin add dsh-model-selector` |
+| [dsh-model-selector](https://github.com/bitterSmilezzz/dsh-model-selector) | provider 分组折叠 + 名称搜索的模型选择器增强（已删除） | 1 | `dsh plugin add dsh-model-selector` |
 | [dsh-local-filetree](https://github.com/Mongfayi/dsh-local-filetree) | 右侧详情列显示当前会话工作区文件树（懒加载、只读） | 1 | `dsh plugin add dsh-local-filetree` |
 | [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) | 把滚出屏幕的折叠标签（Think/工具卡）钉在视口顶部 | 3 | `dsh plugin add dsh-sticky-disclosure` |
 | [dsh-token-usage](https://github.com/hashdiana/dsh-token-usage) | 更美观的 Token 用量条：上下文占用/输入输出/缓存分解/首字延迟 | 2 | `dsh plugin add dsh-token-usage` |
-| [dsh-model-config-sync](https://github.com/LiangYin233/dsh-model-config-sync) | 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 | 11 | `dsh plugin add dsh-model-config-sync` |
-| [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2397 | `dsh plugin add dsh-web-ui` |
-| [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览 | 98 | `dsh plugin add @dsh-external/dsh-visualize` |
-| [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景 | 91 | `dsh plugin add @omdsh-dev/dsh-genui` |
+| [dsh-model-config-sync](https://github.com/LiangYin233/dsh-provider-model-configurator) | 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 | 11 | `dsh plugin add dsh-model-config-sync` |
+| [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2484 | `dsh plugin add dsh-web-ui` |
+| [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览 | 100 | `dsh plugin add @dsh-external/dsh-visualize` |
+| [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景 | 99 | `dsh plugin add @omdsh-dev/dsh-genui` |
 | [web-components](https://github.com/omdsh-dev/web-components) | Web Components 支持 | 2 | `dsh plugin add @deepseek-ai/dsh-client-web-component` |
 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | OpenPencil 设计预览与编辑（Agent 操作真实设计画布） | 74 | `dsh plugin add @zseven-w/dsh-openpencil` |
 
@@ -129,31 +130,31 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1120 | `dsh plugin add dsh-cc-tui` |
-| [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 终端 TUI（天枢） | 149 | `dsh plugin add @huiliyi37/dsh-tianshu-tui` |
+| [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1157 | `dsh plugin add dsh-cc-tui` |
+| [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 终端 TUI（天枢） | 153 | `dsh plugin add @huiliyi37/dsh-tianshu-tui` |
 | [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) | Pi TUI 前端：流式 markdown、思考折叠、工具卡、斜杠命令 | 1 |  |
 | [deepseek-harness-tui](https://github.com/gxinxing/deepseek-harness-tui) | Ink/React 终端原生 TUI | 7 | `dsh plugin add deepseek-harness-tui` |
 | [dsh-tui](https://github.com/orriduck/dsh-tui) | 轻量、会话感知的终端 UI | 2 | `dsh plugin add dsh-tui` |
-| [dsh-tui](https://github.com/openguardrails/dsh-tui) | Claude Code 风格终端 UI（out-of-tree bundle） | 15 | `dsh plugin add @openguardrails/dsh-tui` |
-| [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验 | 181 | `dsh plugin add @oh-dsh/desktop` |
-| [oh-dsh-desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | 可扩展 macOS 工作台：原生 PTY、工作区工具、双语插件、隔离预览市场 | 181 |  |
+| [dsh-tui](https://github.com/dsh-tui/dsh-tui) | Claude Code 风格终端 UI（out-of-tree bundle） | 15 | `dsh plugin add @dsh-tui/dsh-tui` |
+| [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验 | 184 | `dsh plugin add @oh-dsh/desktop` |
 | [deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面壳：1:1 官方 Web UI + 内置服务器托管 + 托盘驻留 | 10 |  |
-| [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) | 非官方进程内 Windows 桌面应用（托盘 + 原生通知 + IPC） | 1 |  |
-| [dsh-desktop](https://github.com/bruc3van/dsh-desktop) | 社区维护的非官方桌面客户端（复用官方实例或内置运行时） | 25 |  |
+| [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop-windows) | 非官方进程内 Windows 桌面应用（托盘 + 原生通知 + IPC） | 1 |  |
+| [dsh-desktop](https://github.com/bruc3van/dsh-desktop) | 社区维护的非官方桌面客户端（复用官方实例或内置运行时） | 29 |  |
 | [dsh-desktop](https://github.com/zsyu9779/dsh-desktop) | Wails(Go) 桌面壳，Codex 风格原生应用 | 4 |  |
 | [dsh-desktop](https://github.com/mrbbbaixue/dsh-desktop) | .NET 10 WPF + WebView2 桌面启动器 | 2 |  |
-| [dsh-desktop](https://github.com/dataelement/dsh-desktop) | 跨平台桌面应用 | 217 |  |
+| [dsh-desktop](https://github.com/dataelement/dsh-desktop) | 跨平台桌面应用 | 221 |  |
 | [dsh-desktop-electron](https://github.com/Void0312Aurora/dsh-desktop-electron) | 跨平台 Electron 桌面壳（托盘驻留、无内置 Node） | 4 |  |
-| [dsh-mac-desktop](https://github.com/bitterSmilezzz/dsh-mac-desktop) | 在原生 macOS 窗口打开 Web GUI（SwiftUI + WKWebView） | 2 | `dsh plugin add dsh-mac-desktop` |
+| [dsh-mac-desktop](https://github.com/bitterSmilezzz/dsh-mac-desktop) | 在原生 macOS 窗口打开 Web GUI（SwiftUI + WKWebView）（已删除） | 2 | `dsh plugin add dsh-mac-desktop` |
 | [dsh-desktop-window](https://github.com/fengzhiyushui/dsh-desktop-window) | 以独立应用窗口打开 Web UI（自动开窗 + 设置开关） | 1 | `dsh plugin add dsh-desktop-window` |
-| [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4287 |  |
-| [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web | 80 | `dsh plugin add deepseek-harness-desktop` |
-| [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器：开机自启 + 独立小窗口 | 89 |  |
-| [dsh-work](https://github.com/vibeinging/dsh-work) | 本地 AI 工作桌面：Session/文件/数据分析/MCP/Office 一体化 | 115 |  |
+| [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4668 |  |
+| [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web | 81 | `dsh plugin add deepseek-harness-desktop` |
+| [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器：开机自启 + 独立小窗口 | 92 |  |
+| [dsh-work](https://github.com/vibeinging/deepseek-harness-desktop-app) | 本地 AI 工作桌面：Session/文件/数据分析/MCP/Office 一体化 | 115 |  |
 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场 | 5 |  |
-| [dsh-mobileweb-adapter](https://github.com/dsh-external/dsh-mobileweb-adapter) | 手机 Web 适配器：让 Web GUI 在手机上可用（⚠️ dsh-external，公开性待核实） |  |  |
-| [dsh-mobile](https://github.com/dsh-external/dsh-mobile) | 移动端客户端（⚠️ dsh-external，公开性待核实） | 12 |  |
-| [dsh-android](https://github.com/dsh-external/dsh-android) | 在 Android 上运行 dsh（⚠️ dsh-external，公开性待核实） |  |  |
+| [dsh-mobileweb-adapter](https://github.com/dsh-external/dsh-mobileweb-adapter) | 手机 Web 适配器：让 Web GUI 在手机上可用（⚠️ dsh-external，已删除） |  |  |
+| [dsh-mobile](https://github.com/lehhair/dsh-mobile) | 移动端客户端（⚠️ dsh-external，公开性待核实） | 12 |  |
+| [dsh-android](https://github.com/dsh-external/dsh-android) | 在 Android 上运行 dsh（⚠️ dsh-external，已删除） |  |  |
+| [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) | Rust/ratatui 编写的 DSH 终端 TUI | 25 | `dsh plugin add github:openma-ai/deepseek-harness-tui` |
 
 [↩ 回到 🖥️ 桌面端 / TUI / 移动端 分类页](desktop-tui-mobile.md)
 
@@ -161,18 +162,18 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | AgentTeams 多智能体团队协作 | 302 | `dsh plugin add dsh-agent-teams` |
-| [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | 把 UltraCode 式多 Agent 调度带给 DSH：可生成/保存/治理/观察/恢复的 Workflow 层 | 55 | `dsh plugin add @dsh-external/workflow` |
+| [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | AgentTeams 多智能体团队协作 | 312 | `dsh plugin add dsh-agent-teams` |
+| [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | 把 UltraCode 式多 Agent 调度带给 DSH：可生成/保存/治理/观察/恢复的 Workflow 层 | 56 | `dsh plugin add @dsh-external/workflow` |
 | [dsh-meta-orchestrator](https://github.com/jiruidai/dsh-meta-orchestrator) | 模型原生 meta-agent：运行时合成任务专属工作流并协调工具/子代理 | 3 | `dsh plugin add dsh-meta-orchestrator` |
 | [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) | 跨会话消息互发：本机任意会话像 Claude Code 一样互发消息 | 2 | `dsh plugin add @dsh-crosstalk/bundle` |
 | [dsh-agent-messaging](https://github.com/happyren/dsh-agent-messaging) | 跨会话 agent-to-agent 消息投递（按会话名寻址） | 4 | `dsh plugin add dsh-agent-messaging` |
-| [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | 跨实例消息/事件交接（interconnect 服务 + 工具） | 26 | `dsh plugin add dsh-interconnect` |
+| [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | 跨实例消息/事件交接（interconnect 服务 + 工具） | 27 | `dsh plugin add dsh-interconnect` |
 | [dsh-session-hub](https://github.com/Asaiuta/dsh-session-hub) | 多服务器 DSH 会话聚合与原生操控（hub 网关 + 官方 UI 桥） | 3 | `dsh plugin add dsh-session-hub` |
 | [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) | 可配置子代理 profiles + 实时工具调用/token 显示 + 子会话跳转 | 7 | `dsh plugin add @huanlin/dsh-plugin-yet-another-subagent` |
-| [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) | 双模型 plan/execute 路由（planner 想、executor 做）⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-a2a](https://github.com/dsh-external/dsh-a2a) | Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 | 4 |  |
-| [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) | 子代理树可视化 ⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) | 团队协作（cordis）⚠️ dsh-external，公开性待核实 |  |  |
+| [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) | 双模型 plan/execute 路由（planner 想、executor 做）⚠️ dsh-external，已删除 |  |  |
+| [dsh-a2a](https://github.com/dpskh/dsh-a2a) | Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 | 4 |  |
+| [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) | 子代理树可视化 ⚠️ dsh-external，已删除 |  |  |
+| [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) | 团队协作（cordis）⚠️ dsh-external，已删除 |  |  |
 
 [↩ 回到 🤖 Agent 编排 / 多 Agent 分类页](agent-orchestration.md)
 
@@ -180,11 +181,11 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） | 76 |  |
+| [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） | 82 |  |
 | [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：模型决定何时压缩（移植自 billion-context-pi） | 12 |  |
 | [dsh-memory](https://github.com/Jesse-njx/dsh-memory) | 基于无损会话日志的引用式记忆（事实带 sessionId/eventRange 引用） | 2 | `dsh plugin add @dsh-memory/bundle` |
 | [dsh-memory](https://github.com/ben7am1n/dsh-memory) | 跨会话 SQLite 持久记忆 | 1 | `dsh plugin add dsh-memory` |
-| [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 本地三层记忆（Runtime Memory/可检索文档/受监督 Memory Spaces） | 25 | `dsh plugin add dsh-mnemon` |
+| [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 本地三层记忆（Runtime Memory/可检索文档/受监督 Memory Spaces） | 26 | `dsh plugin add dsh-mnemon` |
 | [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) | 给所有 AI 工具共用的一层记忆（Context Bundle 注入 + MCP 工具 + 线程捕获） | 5 | `dsh plugin add nowledge-mem-deepseek-harness` |
 | [dsh-plugin-meta-memory](https://github.com/YYTbit/dsh-plugin-meta-memory) | 结构化长期记忆系统 | 2 | `dsh plugin add dsh-plugin-meta-memory` |
 | [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) | 从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5） | 2 | `dsh plugin add @dsh-external/dsh-kb-sieve` |
@@ -193,13 +194,13 @@
 | [context-vista](https://github.com/GooodWei/context-vista) | `/context` 命令 + 环形图实时展示上下文 token 用量与费用 | 4 | `dsh plugin add context-vista` |
 | [distill](https://github.com/LoserFox/distill) | 自动对话蒸馏：后台 subagent 反省 + 技能 create/update | 17 | `dsh plugin add @loserfox/distill` |
 | [dsh-auto-compact](https://github.com/wangxiang0605qvq/dsh-auto-compact) | compact_now 工具，回合结束自动压缩上下文 |  |  |
-| [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) | 上下文管理：节省、注意力优化、压缩档案馆 ⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-context](https://github.com/bowenliang123/dsh-context) | 上下文洞察面板：展示模型上下文窗口的构成与演化 | 38 | `dsh plugin add dsh-context` |
+| [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) | 上下文管理：节省、注意力优化、压缩档案馆 ⚠️ dsh-external，已删除 |  |  |
+| [dsh-context](https://github.com/bowenliang123/dsh-context) | 上下文洞察面板：展示模型上下文窗口的构成与演化 | 40 | `dsh plugin add dsh-context` |
 | [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) | 对话回退：基于持久 Change Ledger 回滚会话与工作区状态 | 50 | `dsh plugin add @dsh-external/turn-rewind` |
 | [dsh-undo](https://github.com/LingLambda/dsh-undo) | 上下文 undo/redo：回退到上一个已完成步骤并恢复 | 3 | `dsh plugin add dsh-undo` |
 | [dsh-recall](https://github.com/Mongfayi/dsh-recall) | 消息撤回：每条用户消息一个撤销按钮，删除该轮及其后内容（不改代码） | 3 | `dsh plugin add dsh-recall` |
-| [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) | `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行 | 6 | `dsh plugin add @dsh-external/dsh-sidechain` |
-| [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) | 基于分支的消息编辑、reroll、重试与版本时间线 | 20 | `dsh plugin add dsh-message-edit` |
+| [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) | `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行 | 7 | `dsh plugin add @dsh-external/dsh-sidechain` |
+| [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) | 基于分支的消息编辑、reroll、重试与版本时间线 | 21 | `dsh plugin add dsh-message-edit` |
 | [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) | 跨 dsh/Codex/Claude/pi/OpenCode 会话的无索引全文搜索 | 2 |  |
 | [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话 | 29 | `dsh plugin add dsh-chat-import` |
 | [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH | 3 | `dsh plugin add dsh-claude-move` |
@@ -210,9 +211,9 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1664 | `dsh plugin add @liustack/modlens` |
-| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts | 401 | `dsh plugin add @dsh-external/dsh-vision-toolkit` |
-| [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) | 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） | 882 |  |
+| [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1736 | `dsh plugin add @liustack/modlens` |
+| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts | 409 | `dsh plugin add @dsh-external/dsh-vision-toolkit` |
+| [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) | 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） | 887 |  |
 | [dsh-vision](https://github.com/william-jin-cmu/dsh-vision) | view_image 工具桥接任意 OpenAI 兼容 VLM（默认智谱免费档） | 23 |  |
 | [dsh-vision-LMstudio](https://github.com/TiankunDai/dsh-vision-LMstudio) | 通过 LM Studio 调用本地视觉模型 | 1 |  |
 | [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | DeepSeek 大脑 + 自动识图（图片经 Qwen VLM 转文字后作答） | 8 | `dsh plugin add dsh-vision-proxy` |
@@ -226,7 +227,7 @@
 | [dsh-mobile-control](https://github.com/PangYiMing/dsh-mobile-control) | 操控手机（ADB/iOS） | 2 | `dsh plugin add dsh-mobile-control` |
 | [dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 原生鸿蒙设备桥：hdc 截图-看图-装包-验证闭环调试 | 5 | `dsh plugin add dsh-hdc-bridge` |
 | [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) | provider 无关的 AIGC HTTP 桥 + 自由画布 + ffmpeg 后处理 | 6 | `dsh plugin add @huanlin/dsh-plugin-aigc-canvas` |
-| [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） | 108 | `dsh plugin add dsh-vision-router` |
+| [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） | 111 | `dsh plugin add dsh-vision-router` |
 
 [↩ 回到 👁️ 多模态 / 视觉 分类页](multimodal.md)
 
@@ -235,16 +236,16 @@
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | 自适应深度研究编排器（基于官方 workflow 引擎） | 12 | `dsh plugin add @dsh-external/dsh-deep-research` |
-| [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) | 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） | 4 | `dsh plugin add @deepseek-ai/dsh-deepresearch` |
+| [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) | 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） | 5 | `dsh plugin add @deepseek-ai/dsh-deepresearch` |
 | [dsh-loop](https://github.com/vlln/dsh-loop) | 定时循环：`/loop` 命令 + loop 工具 + 活动状态条 | 3 | `dsh plugin add @dsh-external/dsh-loop` |
 | [dsh-sentinel](https://github.com/fuhefei/dsh-sentinel) | 条件驱动唤醒：file/command/http/process/webhook 持久监视触发 agent | 7 | `dsh plugin add @dsh-external/dsh-sentinel` |
-| [dsh-automation](https://github.com/titanwings/dsh-automation) | 定时任务：Coding 任务按计划在全新 Agent Session 中运行 | 37 | `dsh plugin add @dsh-external/dsh-automation` |
+| [dsh-automation](https://github.com/titanwings/dsh-automation) | 定时任务：Coding 任务按计划在全新 Agent Session 中运行 | 39 | `dsh plugin add @dsh-external/dsh-automation` |
 | [dsh-routines](https://github.com/Jesse-njx/dsh-routines) | cron 定时 Agent：按计划跑 prompt 并把摘要送到你所在处 | 1 | `dsh plugin add @dsh-routines/bundle` |
 | [dsh-plannotator](https://github.com/titanwings/dsh-plannotator) | 计划批注：选中计划原文逐条批注并回送结构化反馈 | 5 | `dsh plugin add @dsh-external/dsh-plannotator` |
 | [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) | 发现问题→修复→复查的对抗式闭环（基于官方 workflow 引擎） | 5 | `dsh plugin add @dsh-external/dsh-inspect` |
-| [dsh-advisor](https://github.com/btspoony/dsh-advisor) | 副模型每轮被动审查并注入见解 | 9 | `dsh plugin add dsh-advisor` |
-| [mstar-harness](https://github.com/btspoony/mstar-harness) | Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 | 45 |  |
-| [dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) | 基于角色的模型重试/备用策略 | 4 | `dsh plugin add dsh-llm-fallbacks` |
+| [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) | 副模型每轮被动审查并注入见解 | 9 | `dsh plugin add dsh-advisor` |
+| [mstar-harness](https://github.com/btspoony/mstar-harness) | Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 | 46 |  |
+| [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) | 基于角色的模型重试/备用策略 | 4 | `dsh plugin add dsh-llm-fallbacks` |
 | [dsh-polyglot](https://github.com/Jesse-njx/dsh-polyglot) | 模型切换器：任意 OpenAI 兼容端点 + 免费/低价 DeepSeek 预设 + 限流自动回退 | 1 | `dsh plugin add @dsh-polyglot/bundle` |
 | [dsh-track](https://github.com/fakechris/dsh-track) | 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储 | 6 | `dsh plugin add @deepseek-ai/dsh-track` |
 | [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay) | 录制 macOS 桌面工作流演示并转成 agent 技能（orr_* 工具） | 7 | `dsh plugin add dsh-record-replay` |
@@ -254,6 +255,7 @@
 | [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) | 手动审批模式（Manual/Ask Mode） | 1 | `dsh plugin add dsh-tool-approval` |
 | [dsh-tiered-approval](https://github.com/Elaina-real/dsh-tiered-approval) | 分层自动审查：静态规则 + LLM 审查 + 人工兜底 | 2 | `dsh plugin add dsh-tiered-approval` |
 | [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | 事件流审计面板：观察事件类型/分发模式/计数，帮插件作者理解内部 | 1 | `dsh plugin add @dsh-external/dsh-event-auditor` |
+| [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | 自动续传：网络中断后自动发「继续」恢复请求 | 15 | `dsh plugin add github:HsiangNianian/dsh-auto-continue` |
 
 [↩ 回到 🔁 工作流 / 自动化 分类页](workflow-automation.md)
 
@@ -265,20 +267,19 @@
 | [dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram 运行时适配器（per-chat 会话、allowlist 认证） | 1 | `dsh plugin add dsh-telegram` |
 | [DSH-Telegram-Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) | 通过 Telegram 远程对话并接收通知 | 5 | `dsh plugin add dsh-telegram-relay` |
 | [dsh-chatnode-wechat](https://github.com/Jesse-njx/dsh-chatnode-wechat) | 通过 iLink 网关在微信里与 DSH agent 聊天/监控/审批 | 2 | `dsh plugin add @dsh-cowork/chatnode-wechat` |
-| [dsh-lark](https://github.com/Roy-oss1/dsh-lark) | 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片 | 2 | `dsh plugin add @dsh-contrib/dsh-lark-channel` |
+| [dsh-lark](https://github.com/Roy-oss1/dsh-lark) | 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片（已删除） | 2 | `dsh plugin add @dsh-contrib/dsh-lark-channel` |
 | [dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) | 双向飞书控制器 | 7 | `dsh plugin add dsh-lark-bridge` |
 | [dsh-onlyne](https://github.com/dbydd/dsh-onlyne) | IM 网关：从 dsh 会话收发 QQ/微信/飞书/Telegram 消息 | 2 |  |
-| [dsh-notification](https://github.com/omdsh-dev/dsh-notification) | 回合完成桌面通知，按结果分控 + 关键词过滤 | 45 | `dsh plugin add dsh-notification` |
+| [dsh-notification](https://github.com/omdsh-dev/dsh-notification) | 回合完成桌面通知，按结果分控 + 关键词过滤 | 47 | `dsh plugin add dsh-notification` |
 | [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) | Windows 通知（零依赖） | 3 |  |
 | [dsh-win-notify](https://github.com/MuziIsabel/dsh-win-notify) | Windows toast 通知（任务完成带声音） | 4 | `dsh plugin add dsh-win-notify` |
 | [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) | 桌面通知提醒 | 12 | `dsh plugin add @bill9109/dsh-web-ui-notify` |
-| [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) | 会话完成等四种状态通知，支持浏览器提示 | 6 | `dsh plugin add @dingyi222666/dsh-session-notification` |
+| [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) | 会话完成等四种状态通知，支持浏览器提示 | 7 | `dsh plugin add @dingyi222666/dsh-session-notification` |
 | [dsh-ssh](https://github.com/UynajGI/dsh-ssh) | SSH 远程执行（ProxyJump 链、SFTP 文件系统、PTY） | 4 |  |
 | [dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | 通用 webhook 接收器：POST /hook/:channel 唤醒 per-channel agent | 1 | `dsh plugin add dsh-webhook-bridge` |
-| [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) | 从 Web GUI 一键在 VS Code 中打开工作区目录 | 41 | `dsh plugin add dsh-open-in-vscode` |
-| [dsh-share](https://github.com/hellodigua/dsh-share) | 一键分享你的对话 | 18 | `dsh plugin add @dsh-external/dsh-share` |
+| [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) | 从 Web GUI 一键在 VS Code 中打开工作区目录 | 42 | `dsh plugin add dsh-open-in-vscode` |
+| [dsh-share](https://github.com/hellodigua/dsh-share) | 一键分享你的对话 | 19 | `dsh plugin add @dsh-external/dsh-share` |
 | [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) | 分享任意段落的对话 | 1 | `dsh plugin add @bill9109/dsh-conversation-share` |
-| [dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) | BitFun 与 DSH 的 ACP 交互对接 | 9 | `dsh plugin add dsh-acp-for-bitfun` |
 
 [↩ 回到 📡 通知 / 渠道 / 远程 分类页](notifications-channels.md)
 
@@ -286,7 +287,7 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [dsh-browser](https://github.com/Lum1104/dsh-browser) | Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） | 133 |  |
+| [dsh-browser](https://github.com/Lum1104/dsh-browser) | Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） | 140 |  |
 | [dsh-browser-control](https://github.com/PangYiMing/dsh-browser-control) | CDP/Playwright 操控浏览器 | 1 | `dsh plugin add dsh-browser-control` |
 | [ego-browser](https://github.com/Fisfzy/ego-browser) | 把 ego-lite（给 AI Agent 的 Chromium）接入 DSH，13 个结构化 ego_* 工具 | 13 |  |
 | [dsh-better-browser](https://github.com/titanwings/dsh-better-browser) | 通过 Kimi WebBridge 让 Agent 操作用户已登录浏览器（13 个工具） | 7 | `dsh plugin add @dsh-external/dsh-better-browser` |
@@ -295,13 +296,13 @@
 | [DSH-Chrome-devtools](https://github.com/yuzi-ska/DSH-Chrome-devtools) | 基于 Chrome DevTools MCP 的真实 Chrome 控制 | 1 | `dsh plugin add dsh-chrome-devtools` |
 | [dsh-playwright-cli](https://github.com/mitao-su/dsh-playwright-cli) | 包装 Playwright CLI：装浏览器、跑测试、从 agent 循环打开 HTML 报告 | 2 | `dsh plugin add dsh-playwright-cli` |
 | [deepseek-pp](https://github.com/zhu1090093659/deepseek-pp) | 浏览器扩展 AI Agent 工作区，内置 MCP 与记忆 | 1558 |  |
-| [dsh-webfetch](https://github.com/withlovehub/dsh-webfetch) | 零依赖 webfetch MCP server（robots 合规、SSRF 防护） | 2 |  |
 | [dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方接入内置 web_search | 2 | `dsh plugin add @yangzhe1003/dsh-web-search-firecrawl` |
 | [dsh-web-search-tavily](https://github.com/crayonlu/dsh-web-search-tavily) | Tavily 搜索提供方（免 DeepSeek key） | 3 |  |
 | [dsh-tavily-search](https://github.com/zhouzhencheng07/dsh-tavily-search) | 免 key Tavily 搜索工具 | 2 | `dsh plugin add dsh-tavily-search` |
 | [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) | 增强持久搜索（多引擎 + SQLite/LRU 缓存 + Playwright 渲染） | 7 | `dsh plugin add dsh-web-search-pro` |
 | [dsh-all-search](https://github.com/RealAlexandreAI/dsh-all-search) | AnySearch 网页搜索提供方（ctx.web） | 1 | `dsh plugin add dsh-all-search` |
-| [modsearch](https://github.com/liustack/modsearch) | CLI 搜索工具：把搜索查询转结构化 web 证据 JSON | 103 | `dsh plugin add @liustack/modsearch` |
+| [modsearch](https://github.com/liustack/modsearch) | CLI 搜索工具：把搜索查询转结构化 web 证据 JSON | 104 | `dsh plugin add @liustack/modsearch` |
+| [argo](https://github.com/taxueseek/argo) | 为 agent 打造的多语言搜索工具（中文/英文/学术/代码/购物/金融/新闻/百科） | 77 | `dsh plugin add github:taxueseek/argo` |
 
 [↩ 回到 🌐 浏览器 / 搜索 分类页](browser-search.md)
 
@@ -309,14 +310,13 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [plugin-registry](https://github.com/dsh-external/plugin-registry) | 第三方本地插件系统：`dsh.plugin.json` 协议 + install/enable/disable + Web 面板（公开） | 40 |  |
 | [plugin-registry](https://github.com/vlln/plugin-registry) | 插件管理控制台：浏览器面板管理官方 repository 插件 + 开发引导 | 40 |  |
 | [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) | 离线容忍的注册表：从 awesome 列表/GitHub topics/npm 发现并去重 DSH 插件 | 1 |  |
 | [dsh-hub](https://github.com/omdsh-dev/dsh-hub) | OMDSH 社区扩展 hub（基于官方 contracts） | 4 | `dsh plugin add @omdsh/dsh-hub` |
 | [DSH-plugin-switch](https://github.com/Nexus-Aethra/DSH-plugin-switch) | 插件市场：浏览/搜索/安装 GitHub 项目，自动识别 plugin/skill | 2 | `dsh plugin add dsh-plugin-switch` |
 | [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) | 把 DSH 快速接入 GitHub 插件生态的市场插件 | 6 | `dsh plugin add dsh-plugin-installer` |
-| [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） | 39 | `dsh plugin add @dsh-external/dsh-super-injector` |
-| [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop | 46 |  |
+| [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） | 48 | `dsh plugin add @dsh-external/dsh-super-injector` |
+| [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop | 47 |  |
 | [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) | 插件健康检查：扫描清单协议/patch 格式/构建陷阱/hub 状态 | 17 | `dsh plugin add @deepseek-ai/dsh-plugin-check` |
 | [dsh-plugin-doctor](https://github.com/lin-cheng-lab/dsh-plugin-doctor) | 插件体检：安装前检查 peer 版本兼容性 | 1 | `dsh plugin add dsh-plugin-doctor` |
 | [dsh-doctor](https://github.com/asdf17128/dsh-doctor) | profile 健康检查：找 patch 静默破坏的配置/死 patch/工具名冲突 | 1 |  |
@@ -341,6 +341,8 @@
 | [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) | Multica 的 DSH runtime 桥接（stdio JSONL 协议） | 34 | `dsh plugin add @multica-ai/dsh-runtime` |
 | [session-teleport](https://github.com/omdsh-dev/session-teleport) | PostgreSQL 单写者会话交接服务 | 2 | `dsh plugin add @mattheliu/session-teleport` |
 | [session-persistence-rdb](https://github.com/morlay/session-persistence-rdb) | session 关系型数据库持久化 | 4 | `dsh plugin add @morlay/session-persistence-rdb` |
+| [dsh-market](https://github.com/dsh-market/dsh-market) | DSH 可视化插件市场：浏览/搜索/一键安装 | 221 | `dsh plugin add github:dsh-market/dsh-market` |
+| [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) | dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin 目录/安装/卸载 | 42 | `dsh plugin add github:Sanqi-normal/dsh-webui-market-plugin` |
 
 [↩ 回到 🏗️ 基础设施 / 插件管理 / 开发工具 分类页](infrastructure-dev.md)
 
@@ -353,13 +355,13 @@
 | [dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) | 自走棋：人机对战或双 AI 对弈 | 3 | `dsh plugin add @deepseek-ai/dsh-auto-chess` |
 | [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) | 模型生成时弹出小游戏菜单（wordle/消消乐，可扩展） | 5 | `dsh plugin add @huanlin/dsh-plugin-d399` |
 | [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) | 全手绘像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心） | 30 |  |
-| [whale-girl](https://github.com/vlln/whale-girl) | 桌面宠物鲸鱼娘（QQ 宠物形态，可拖拽/投喂/玩耍） | 159 | `dsh plugin add whale-girl` |
+| [whale-girl](https://github.com/vlln/whale-girl) | 桌面宠物鲸鱼娘（QQ 宠物形态，可拖拽/投喂/玩耍） | 160 | `dsh plugin add whale-girl` |
 | [dsh-pixel-whale](https://github.com/yoke233/dsh-pixel-whale) | 活泼像素鲸鱼运行状态伴侣 | 1 | `dsh plugin add dsh-pixel-whale` |
 | [dsh-blue-whale-maid](https://github.com/yuxino/dsh-blue-whale-maid) | 蓝鲸女仆桌面像素宠物 | 3 | `dsh plugin add dsh-blue-whale-maid` |
-| [deepseek-pet](https://github.com/keleus/deepseek-pet) | 在 DSH 上养一只大蓝鲸 | 15 | `dsh plugin add deepseek-pet` |
-| [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) | 用户与 agent 双向表情贴纸互动 | 15 | `dsh plugin add @dsh-external/dsh-stickers` |
+| [deepseek-pet](https://github.com/keleus/deepseek-pet) | 在 DSH 上养一只大蓝鲸 | 18 | `dsh plugin add deepseek-pet` |
+| [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) | 用户与 agent 双向表情贴纸互动 | 16 | `dsh plugin add @dsh-external/dsh-stickers` |
 | [dsh-emoji](https://github.com/hellodigua/dsh-emoji) | 为 AI 回复自动添加表情 | 17 | `dsh plugin add @dsh-external/dsh-emoji` |
-| [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 2005 中文站点风格整活广告（侧栏/信息流/弹窗，素材全虚构） | 388 | `dsh plugin add @dsh-external/dsh-ads` |
+| [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 2005 中文站点风格整活广告（侧栏/信息流/弹窗，素材全虚构） | 396 | `dsh plugin add @dsh-external/dsh-ads` |
 | [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) | 股票行情数据插件（整活向） | 11 | `dsh plugin add dsh-stock-market` |
 | [dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) | 侧栏短视频：原生播放器、系列导航、历史回放 | 2 | `dsh plugin add dsh-douyin` |
 | [deepseek-manners](https://github.com/Moeblack/deepseek-manners) | 每次消息后注入感谢语，做个有礼貌的人 | 10 | `dsh plugin add deepseek-manners` |
@@ -367,15 +369,18 @@
 | [dsh-fun-typewriter](https://github.com/omdsh-dev/dsh-fun-typewriter) | WebAudio 打字机氛围音效（零音频资源） | 3 | `dsh plugin add @deepseek-ai/dsh-fun-typewriter` |
 | [dsh-daily-fortune](https://github.com/omdsh-dev/dsh-daily-fortune) | 每日运势：观音签、塔罗、每日一句 | 3 | `dsh plugin add @deepseek-ai/dsh-daily-fortune` |
 | [dsh-plugin-spur](https://github.com/HuanLinOTO/dsh-plugin-spur) | 挂在聊天流里的辫子，抓住甩一甩给 agent 发「去干活」 | 3 | `dsh plugin add @huanlin/dsh-plugin-spur` |
-| [dsh-toy](https://github.com/c3ll256/dsh-toy) | 连接小型玩具到 DSH（Toy Control Protocol） | 38 | `dsh plugin add dsh-toy` |
+| [dsh-toy](https://github.com/c3ll256/dsh-toy) | 连接小型玩具到 DSH（Toy Control Protocol） | 43 | `dsh plugin add dsh-toy` |
 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | 费曼学习模式：教→讲回→判→再解释，渲染为富 HTML 课程卡 | 4 | `dsh plugin add dsh-learn-everything` |
 | [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) | OpenMAIC 教学：课堂、幻灯片、交互组件、苏格拉底式教学 | 8 | `dsh plugin add @openmaic/dsh-openmaic` |
 | [dsh-scholar](https://github.com/lzszq/dsh-scholar) | 学术助手插件 | 15 | `dsh plugin add @dsh-scholar/research-plugin` |
 | [dsh-101](https://github.com/bill9109/dsh-101) | DSH 文档阅读模式 | 3 | `dsh plugin add @dsh-external/dsh-101` |
 | [dsh-reasoning-translator](https://github.com/pinkllo/dsh-reasoning-translator) | 让模型的思维链用你的语言输出 | 2 | `dsh plugin add dsh-reasoning-translator` |
-| [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | OpenPencil 设计预览与编辑（Agent 操作真实设计画布） | 74 | `dsh plugin add @zseven-w/dsh-openpencil` |
 | [dsh-director-toolkit](https://github.com/lhmd/dsh-director-toolkit) | 3D 艺术家/技术美术方向包：Blender/Three.js/Houdini/C4D 方向指引 | 7 | `dsh plugin add @lhmd/dsh-director-toolkit` |
 | [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) | Xcode AI 集成：26 个 Xcode MCP 工具 + Apple 平台技能 | 1 | `dsh plugin add dsh-apple-mode` |
+| [notes](https://github.com/zhaoolee/notes) | 开源版锤子便签：导出 DSH 会话为便签图片，支持 skill 调用 ⚠️ 无 license 文件 | 142 |  |
+| [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) | DSH 会话费用统计（本会话/当日/历史 + 官方价格同步） | 31 | `dsh plugin add github:Han-1413141/dsh-cost-meter` |
+| [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) | persona 驱动的 UX 走查：扫描 React/TS 源码找 UX 问题 | 18 | `dsh plugin add github:DietCokewithSugar/dsh-user-experience` |
+| [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) | DeepSeek 账户余额与会话成本显示 | 13 | `dsh plugin add github:Ghost011118/dsh-balance-meter` |
 
 [↩ 回到 🎮 娱乐 / 其他 分类页](fun-other.md)
 
@@ -383,22 +388,21 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 107568 |  |
-| [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5850 |  |
-| [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2326 |  |
-| [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) | 「30 秒找到适合你的插件」，带场景说明 + 505 全量快照 | 132 |  |
-| [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) | DSH 生态精选：插件/工具/基础设施 | 454 |  |
-| [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 928 |  |
-| [Alex-Yanggg/awesome-DSH-plugin](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | 覆盖生产力/扩展/调试/自定义开发的分类 catalog | 61 |  |
-| [dsh-external/hub](https://github.com/dsh-external/hub) | 社区组织级索引/目录元仓库（⚠️ 私有，白名单可见） |  |  |
-| [dsh-external/plugin-registry](https://github.com/dsh-external/plugin-registry) | 第三方插件系统：`dsh.plugin.json` 协议（公开） | 40 |  |
-| [dsh-external/marisa](https://github.com/dsh-external/marisa) | 「寄生式」外部插件管理器 `dshx`（⚠️ 私有，白名单可见） |  |  |
-| [dsh-external/toybox](https://github.com/dsh-external/toybox) | 插件玩具箱：静态 `.dsh-plugin` 格式的技能/MCP 插件收藏（公开） |  |  |
+| [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 109475 |  |
+| [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5853 |  |
+| [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2519 |  |
+| [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) | 「30 秒找到适合你的插件」，带场景说明 + 505 全量快照 | 139 |  |
+| [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) | DSH 生态精选：插件/工具/基础设施 | 465 |  |
+| [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 942 |  |
+| [Alex-Yanggg/awesome-DSH-plugin](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | 覆盖生产力/扩展/调试/自定义开发的分类 catalog | 62 |  |
+| [dsh-external/hub](https://github.com/dsh-external/hub) | 社区组织级索引/目录元仓库（⚠️ 私有，白名单可见） （已删除） |  |  |
+| [dsh-external/marisa](https://github.com/dsh-external/marisa) | 「寄生式」外部插件管理器 `dshx`（⚠️ 私有，白名单可见） （已删除） |  |  |
+| [dsh-external/toybox](https://github.com/dsh-external/toybox) | 插件玩具箱：静态 `.dsh-plugin` 格式的技能/MCP 插件收藏（公开） （已删除） |  |  |
 | [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) | 第三方 Harness：Python 库 + dsh CLI + MCP server + SKILL.md | 40 |  |
 | [vvlife/whalehub-dsh](https://github.com/vvlife/whalehub-dsh) | 第三方插件商店/中心 | 4 |  |
-| [dsh-plugin-guide](https://github.com/dsh-external/dsh-plugin-guide) | DSH 插件开发指南：从零到精通 ⚠️ 公开性待核实 |  |  |
-| [dsh-cordis-rocks](https://github.com/dsh-external/dsh-cordis-rocks) | 16 章可逆 Cordis 配套教程 ⚠️ 公开性待核实 |  |  |
-| [dsh-cordis-examples](https://github.com/dsh-external/dsh-cordis-examples) | 最小原生 DSH/Cordis 扩展示例 ⚠️ 公开性待核实 |  |  |
+| [dsh-plugin-guide](https://github.com/dsh-external/dsh-plugin-guide) | DSH 插件开发指南：从零到精通 ⚠️ 已删除 |  |  |
+| [dsh-cordis-rocks](https://github.com/dsh-external/dsh-cordis-rocks) | 16 章可逆 Cordis 配套教程 ⚠️ 已删除 |  |  |
+| [dsh-cordis-examples](https://github.com/dsh-external/dsh-cordis-examples) | 最小原生 DSH/Cordis 扩展示例 ⚠️ 已删除 |  |  |
 | [plugin-template](https://github.com/omdsh-dev/plugin-template) | 插件模板仓库（基于 turtle-ui） | 5 | `dsh plugin add @your-scope/dsh-plugin-template` |
 
 [↩ 回到 🏛️ 官方核心与元项目 分类页](official-meta.md)

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ Top community plugins by GitHub stars:
 
 | # | Plugin | Description | ⭐ |
 |---|---|---|---|
-| 1 | [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 107568 |
-| 2 | [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5850 |
-| 3 | [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4287 |
-| 4 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2397 |
-| 5 | [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2326 |
-| 6 | [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1664 |
+| 1 | [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 109475 |
+| 2 | [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5853 |
+| 3 | [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4668 |
+| 4 | [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2519 |
+| 5 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2484 |
+| 6 | [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1736 |
 | 7 | [deepseek-pp](https://github.com/zhu1090093659/deepseek-pp) | 浏览器扩展 AI Agent 工作区，内置 MCP 与记忆 | 1558 |
-| 8 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1120 |
-| 9 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 988 |
-| 10 | [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 928 |
+| 8 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1157 |
+| 9 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 1065 |
+| 10 | [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 942 |
 
 <!-- hot:end -->
 
@@ -115,9 +115,9 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化 test_run：自动探测 vitest/jest/pytest/node:test 并解析失败摘要 | 2 | `dsh plugin add dsh-test-runner` |
 | [dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | 密钥/危险模式扫描（API key/token/私钥脱敏，零依赖） | 1 | `dsh plugin add dsh-security-scan` |
 | [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) | 按 agent 的按需工具发现 + 渐进式 schema 披露 | 2 | `dsh plugin add @deepseek-ai/dsh-tool-search` |
-| [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) | 用 Monaco 编辑器创建/管理沙箱化自定义 JS 工具 | 23 | `dsh plugin add dsh-custom-tool` |
+| [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) | 用 Monaco 编辑器创建/管理沙箱化自定义 JS 工具 | 24 | `dsh plugin add dsh-custom-tool` |
 | [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) | 自动识别并解码 Bash 输出编码（UTF-16LE/UTF-8/GBK），修中文乱码 | 7 |  |
-| [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | Codex 风格 `@file` 文件引用，输入框里直接搜索并引用工作区文件 | 187 | `dsh plugin add dsh-at-file` |
+| [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | Codex 风格 `@file` 文件引用，输入框里直接搜索并引用工作区文件 | 198 | `dsh plugin add dsh-at-file` |
 | [dsh-wikilink](https://github.com/zhaoscsc/dsh-wikilink) | Obsidian 风格 `[[wikilink]]` 提及：模糊搜索笔记标题并附加内容 | 3 | `dsh plugin add dsh-wikilink` |
 | [dsh-safe-delete](https://github.com/Qintsg/dsh-safe-delete) | 安全删除：移入回收站/暂存区而非永久删除，支持恢复 | 3 |  |
 | [dsh-bisect-debug](https://github.com/PangYiMing/dsh-bisect-debug) | 二分法定位 bug 根因（代码/边界/commit） | 1 | `dsh plugin add dsh-bisect-debug` |
@@ -125,8 +125,8 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | 让 AI 帮你连数据库、写 SQL | 25 | `dsh plugin add @deepseek-ai/dsh-data-agent` |
 | [dsh-openapi](https://github.com/Degurechaff57/dsh-openapi) | Safe OpenAPI 3.x 发现与 API 调用工具 | 4 | `dsh plugin add dsh-openapi` |
 | [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) | 暴露 run_python / run_node 工具，可配置解释器路径 | 6 | `dsh plugin add @huanlin/dsh-plugin-interpreters` |
-| [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) | doc_read/doc_write：以有界、单元格寻址方式读写 xlsx/pdf/docx/pptx/ipynb | 2 |  |
-| [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) | 向模型暴露 MineRU 文档解析工具 | 18 | `dsh plugin add @huanlin/dsh-plugin-mineru` |
+| [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) | doc_read/doc_write：以有界、单元格寻址方式读写 xlsx/pdf/docx/pptx/ipynb | 3 |  |
+| [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) | 向模型暴露 MineRU 文档解析工具 | 20 | `dsh plugin add @huanlin/dsh-plugin-mineru` |
 | [dsh-plugin-sleep](https://github.com/HuanLinOTO/dsh-plugin-sleep) | 暴露单个 `sleep` 工具，让模型按需暂停（支持取消） | 6 | `dsh plugin add @huanlin/dsh-plugin-sleep` |
 | [dsh-port-guard](https://github.com/PangYiMing/dsh-port-guard) | 端口占用处置（复用/切换/精确 kill） | 1 | `dsh plugin add dsh-port-guard` |
 | [dsh-scout](https://github.com/omdsh-dev/dsh-scout) | 只读环境探测：运行环境/版本/资源/端口/服务/硬件/工作区 | 2 | `dsh plugin add @deepseek-ai/dsh-tool-scout` |
@@ -134,7 +134,7 @@ Expand any category to browse all plugins inline — no need to leave this page.
 </details>
 
 <details>
-<summary>🧩 Skills · 16</summary>
+<summary>🧩 Skills · 17</summary>
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
@@ -142,18 +142,19 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) | 把已有 Agent Skills（Claude/Codex/Cursor/Gemini 的 SKILL.md）带进 DSH，渐进式索引 + 按需加载 | 2 | `dsh plugin add @dsh-skillport/bundle` |
 | [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) | 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索/安装/生命周期管理 | 2 | `dsh plugin add dsh-find-skill` |
 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | 构建与测试 DSH 插件的 Agent 技能（脚手架到测试分层） | 7 |  |
-| [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | 五阶段「书→技能」长任务（抓取→解析→理解→生成→安装）+ 3 个人工关卡 | 3 | `dsh plugin add dsh-book2skill` |
+| [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | 五阶段「书→技能」长任务（抓取→解析→理解→生成→安装）+ 3 个人工关卡 | 4 | `dsh plugin add dsh-book2skill` |
 | [dsh-superpowers](https://github.com/codeAnqiang-ma/dsh-superpowers) | Superpowers（obra/superpowers）作为 DSH 插件：方法论技能 + 会话引导 | 3 | `dsh plugin add dsh-superpowers` |
 | [dsh-plugin-code-review](https://github.com/YYTbit/dsh-plugin-code-review) | 结构化代码审查技能（YYTbit 系列） | 1 | `dsh plugin add dsh-plugin-code-review` |
 | [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) | 增量 diff 审查：checkpoint 队列 + Web 面板 + 审查意见注入 agent | 2 | `dsh plugin add @dsh-plugin/dsh-review-loop` |
-| [dsh-skill-manager](https://github.com/bitterSmilezzz/dsh-skill-manager) | 在 Web 设置页管理（列出/禁用启用/编辑）skills | 1 | `dsh plugin add dsh-skill-manager` |
+| [dsh-skill-manager](https://github.com/bitterSmilezzz/dsh-skill-manager) | 在 Web 设置页管理（列出/禁用启用/编辑）skills（已删除） | 1 | `dsh plugin add dsh-skill-manager` |
 | [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) | 把 Claude Code 记忆/技能/配置桥接进 DSH | 5 | `dsh plugin add dsh-plugin-claude-bridge` |
 | [dsh-plugin-codex-bridge](https://github.com/YYTbit/dsh-plugin-codex-bridge) | 把 Codex skills/config 桥接进 DSH | 2 | `dsh plugin add dsh-plugin-codex-bridge` |
 | [dsh-plugin-opencode-bridge](https://github.com/YYTbit/dsh-plugin-opencode-bridge) | 把 OpenCode skills/config 桥接进 DSH | 3 | `dsh plugin add dsh-plugin-opencode-bridge` |
 | [dsh-plugin-pi-bridge](https://github.com/YYTbit/dsh-plugin-pi-bridge) | 把 pi skills/config 桥接进 DSH | 2 | `dsh plugin add dsh-plugin-pi-bridge` |
 | [Code2Skill](https://github.com/leechen298/Code2Skill) | 从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发 | 2 | `dsh plugin add github:leechen298/Code2Skill#v1.1.3` |
-| [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） | 13 | `dsh plugin add github:dhicoc/dsh-reverse-skill` |
-| [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) | 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill | 84 | `dsh plugin add github:Nagi-ovo/dsh-find-plugins` |
+| [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） | 12 | `dsh plugin add github:dhicoc/dsh-reverse-skill` |
+| [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) | 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill | 89 | `dsh plugin add github:Nagi-ovo/dsh-find-plugins` |
+| [forkprobe](https://github.com/Jayden-X-L/forkprobe) | 同一任务对比多个 skill 并选出最优 | 66 | `dsh plugin add github:Jayden-X-L/forkprobe` |
 
 </details>
 
@@ -180,7 +181,7 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
 | [dsh-skins](https://github.com/Moeblack/dsh-skins) | Web UI 皮肤合集（含 harbor 夕港黄昏皮肤） | 3 | `dsh plugin add @dsh-external/dsh-web-skins` |
-| [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | DSH Web 鲸鱼娘皮肤系列（深海女仆工坊） | 802 |  |
+| [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | DSH Web 鲸鱼娘皮肤系列（深海女仆工坊） | 834 |  |
 | [dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) | QQ2006 复古皮肤 | 10 |  |
 | [dsh-miku-skin](https://github.com/stushansusu/dsh-miku-skin) | 初音未来主题（蓝紫渐变/毛玻璃/亮暗双主题） | 2 | `dsh plugin add @deepseek-ai/dsh-client-ui-skin-miku` |
 | [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) | 模仿 Excel 的皮肤 | 8 |  |
@@ -190,31 +191,31 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-web-background](https://github.com/BruceWu1126/dsh-web-background) | Web UI 背景自定义 | 2 |  |
 | [dsh-plugin-background](https://github.com/gameswu/dsh-plugin-background) | Web UI 壁纸自定义 | 8 |  |
 | [dsh-chat-width](https://github.com/chen-001/dsh-chat-width) | 调整回复宽度（终端宽度感知） | 3 |  |
-| [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) | 换肤系统：21 套内置皮肤 + 一图生成整套配色 | 33 |  |
-| [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 988 | `dsh plugin add dsh-better-sidebar` |
+| [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) | 换肤系统：21 套内置皮肤 + 一图生成整套配色 | 34 |  |
+| [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 1065 | `dsh plugin add dsh-better-sidebar` |
 | [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) | 侧边栏集成文件浏览器、终端和 Git 审查 | 16 | `dsh plugin add @dsh-external/dsh-side-panel` |
 | [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) | 「聚焦会话」精简视图，只关注最终产出结果 | 16 | `dsh plugin add @dingyi222666/dsh-focus-chat` |
-| [ui-status-label](https://github.com/alingalingling/ui-status-label) | 把鲸鱼娘思考时的 "deep diving" 状态文案自定义 | 31 | `dsh plugin add dsh-ui-status-label` |
-| [dsh-navbar](https://github.com/vlln/dsh-navbar) | 对话节点导航条，右缘节点串快速跳转 user 消息 | 22 | `dsh plugin add @dsh-external/dsh-navbar` |
-| [dsh-task-status](https://github.com/vlln/dsh-task-status) | 后台任务状态条：对话页任务进度 + 实时输出 tail | 9 | `dsh plugin add @dsh-external/dsh-task-status` |
+| [ui-status-label](https://github.com/alingalingling/ui-status-label) | 把鲸鱼娘思考时的 "deep diving" 状态文案自定义 | 32 | `dsh plugin add dsh-ui-status-label` |
+| [dsh-navbar](https://github.com/vlln/dsh-navbar) | 对话节点导航条，右缘节点串快速跳转 user 消息 | 23 | `dsh plugin add @dsh-external/dsh-navbar` |
+| [dsh-task-status](https://github.com/vlln/dsh-task-status) | 后台任务状态条：对话页任务进度 + 实时输出 tail | 10 | `dsh plugin add @dsh-external/dsh-task-status` |
 | [dsh-web-archive](https://github.com/renat3u/dsh-web-archive) | 折叠对话中的 Think、Bash 等「无用消息」 | 7 | `dsh plugin add dsh-web-archive` |
 | [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) | 会话里程碑导航条：像 Git 提交图定位每条提问 | 14 | `dsh plugin add dsh-milestone` |
 | [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) | 键盘优先的命令面板（command palette） | 5 | `dsh plugin add @dsh-external/dsh-spotlight` |
 | [dsh-deeplink](https://github.com/qyw233/dsh-deeplink) | `?session=` / `?workspace=` 深链直达指定项目对话 | 1 | `dsh plugin add @dsh-community/dsh-deeplink` |
-| [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) | PiUI 风格 diff 查看器，替换 write/edit 的默认 DiffBlock | 11 | `dsh plugin add @dsh-external/dsh-diff-viewer` |
+| [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) | PiUI 风格 diff 查看器，替换 write/edit 的默认 DiffBlock | 12 | `dsh plugin add @dsh-external/dsh-diff-viewer` |
 | [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) | 跨平台文件拖拽与原始路径插入，无需复制文件 | 7 | `dsh plugin add @bill9109/dsh-drag-and-drop` |
 | [ex-setting](https://github.com/omdsh-dev/ex-setting) | DSH 的设置扩展 | 2 | `dsh plugin add @deepseek-ai/dsh-ex-setting` |
-| [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | 选中文字→批注→回车随消息发送，回复按批注逐条对照 | 48 | `dsh plugin add @omdsh-dev/dsh-annotation` |
+| [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | 选中文字→批注→回车随消息发送，回复按批注逐条对照 | 50 | `dsh plugin add @omdsh-dev/dsh-annotation` |
 | [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) | 带实时预览的用户/内置 system prompt 分节编辑器 | 2 | `dsh plugin add dsh-prompt-studio` |
 | [dsh-prompt-persona](https://github.com/Xilin3/dsh-prompt-persona) | 从设置页编辑系统提示词（deployment persona），带实时预览 | 4 | `dsh plugin add @xilin3/dsh-prompt-persona` |
-| [dsh-model-selector](https://github.com/bitterSmilezzz/dsh-model-selector) | provider 分组折叠 + 名称搜索的模型选择器增强 | 1 | `dsh plugin add dsh-model-selector` |
+| [dsh-model-selector](https://github.com/bitterSmilezzz/dsh-model-selector) | provider 分组折叠 + 名称搜索的模型选择器增强（已删除） | 1 | `dsh plugin add dsh-model-selector` |
 | [dsh-local-filetree](https://github.com/Mongfayi/dsh-local-filetree) | 右侧详情列显示当前会话工作区文件树（懒加载、只读） | 1 | `dsh plugin add dsh-local-filetree` |
 | [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) | 把滚出屏幕的折叠标签（Think/工具卡）钉在视口顶部 | 3 | `dsh plugin add dsh-sticky-disclosure` |
 | [dsh-token-usage](https://github.com/hashdiana/dsh-token-usage) | 更美观的 Token 用量条：上下文占用/输入输出/缓存分解/首字延迟 | 2 | `dsh plugin add dsh-token-usage` |
-| [dsh-model-config-sync](https://github.com/LiangYin233/dsh-model-config-sync) | 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 | 11 | `dsh plugin add dsh-model-config-sync` |
-| [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2397 | `dsh plugin add dsh-web-ui` |
-| [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览 | 98 | `dsh plugin add @dsh-external/dsh-visualize` |
-| [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景 | 91 | `dsh plugin add @omdsh-dev/dsh-genui` |
+| [dsh-model-config-sync](https://github.com/LiangYin233/dsh-provider-model-configurator) | 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 | 11 | `dsh plugin add dsh-model-config-sync` |
+| [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2484 | `dsh plugin add dsh-web-ui` |
+| [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览 | 100 | `dsh plugin add @dsh-external/dsh-visualize` |
+| [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景 | 99 | `dsh plugin add @omdsh-dev/dsh-genui` |
 | [web-components](https://github.com/omdsh-dev/web-components) | Web Components 支持 | 2 | `dsh plugin add @deepseek-ai/dsh-client-web-component` |
 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | OpenPencil 设计预览与编辑（Agent 操作真实设计画布） | 74 | `dsh plugin add @zseven-w/dsh-openpencil` |
 
@@ -225,31 +226,31 @@ Expand any category to browse all plugins inline — no need to leave this page.
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
-| [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1120 | `dsh plugin add dsh-cc-tui` |
-| [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 终端 TUI（天枢） | 149 | `dsh plugin add @huiliyi37/dsh-tianshu-tui` |
+| [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1157 | `dsh plugin add dsh-cc-tui` |
+| [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 终端 TUI（天枢） | 153 | `dsh plugin add @huiliyi37/dsh-tianshu-tui` |
 | [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) | Pi TUI 前端：流式 markdown、思考折叠、工具卡、斜杠命令 | 1 |  |
 | [deepseek-harness-tui](https://github.com/gxinxing/deepseek-harness-tui) | Ink/React 终端原生 TUI | 7 | `dsh plugin add deepseek-harness-tui` |
 | [dsh-tui](https://github.com/orriduck/dsh-tui) | 轻量、会话感知的终端 UI | 2 | `dsh plugin add dsh-tui` |
-| [dsh-tui](https://github.com/openguardrails/dsh-tui) | Claude Code 风格终端 UI（out-of-tree bundle） | 15 | `dsh plugin add @openguardrails/dsh-tui` |
-| [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验 | 181 | `dsh plugin add @oh-dsh/desktop` |
-| [oh-dsh-desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | 可扩展 macOS 工作台：原生 PTY、工作区工具、双语插件、隔离预览市场 | 181 |  |
+| [dsh-tui](https://github.com/dsh-tui/dsh-tui) | Claude Code 风格终端 UI（out-of-tree bundle） | 15 | `dsh plugin add @dsh-tui/dsh-tui` |
+| [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验 | 184 | `dsh plugin add @oh-dsh/desktop` |
 | [deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面壳：1:1 官方 Web UI + 内置服务器托管 + 托盘驻留 | 10 |  |
-| [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) | 非官方进程内 Windows 桌面应用（托盘 + 原生通知 + IPC） | 1 |  |
-| [dsh-desktop](https://github.com/bruc3van/dsh-desktop) | 社区维护的非官方桌面客户端（复用官方实例或内置运行时） | 25 |  |
+| [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop-windows) | 非官方进程内 Windows 桌面应用（托盘 + 原生通知 + IPC） | 1 |  |
+| [dsh-desktop](https://github.com/bruc3van/dsh-desktop) | 社区维护的非官方桌面客户端（复用官方实例或内置运行时） | 29 |  |
 | [dsh-desktop](https://github.com/zsyu9779/dsh-desktop) | Wails(Go) 桌面壳，Codex 风格原生应用 | 4 |  |
 | [dsh-desktop](https://github.com/mrbbbaixue/dsh-desktop) | .NET 10 WPF + WebView2 桌面启动器 | 2 |  |
-| [dsh-desktop](https://github.com/dataelement/dsh-desktop) | 跨平台桌面应用 | 217 |  |
+| [dsh-desktop](https://github.com/dataelement/dsh-desktop) | 跨平台桌面应用 | 221 |  |
 | [dsh-desktop-electron](https://github.com/Void0312Aurora/dsh-desktop-electron) | 跨平台 Electron 桌面壳（托盘驻留、无内置 Node） | 4 |  |
-| [dsh-mac-desktop](https://github.com/bitterSmilezzz/dsh-mac-desktop) | 在原生 macOS 窗口打开 Web GUI（SwiftUI + WKWebView） | 2 | `dsh plugin add dsh-mac-desktop` |
+| [dsh-mac-desktop](https://github.com/bitterSmilezzz/dsh-mac-desktop) | 在原生 macOS 窗口打开 Web GUI（SwiftUI + WKWebView）（已删除） | 2 | `dsh plugin add dsh-mac-desktop` |
 | [dsh-desktop-window](https://github.com/fengzhiyushui/dsh-desktop-window) | 以独立应用窗口打开 Web UI（自动开窗 + 设置开关） | 1 | `dsh plugin add dsh-desktop-window` |
-| [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4287 |  |
-| [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web | 80 | `dsh plugin add deepseek-harness-desktop` |
-| [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器：开机自启 + 独立小窗口 | 89 |  |
-| [dsh-work](https://github.com/vibeinging/dsh-work) | 本地 AI 工作桌面：Session/文件/数据分析/MCP/Office 一体化 | 115 |  |
+| [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4668 |  |
+| [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web | 81 | `dsh plugin add deepseek-harness-desktop` |
+| [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器：开机自启 + 独立小窗口 | 92 |  |
+| [dsh-work](https://github.com/vibeinging/deepseek-harness-desktop-app) | 本地 AI 工作桌面：Session/文件/数据分析/MCP/Office 一体化 | 115 |  |
 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场 | 5 |  |
-| [dsh-mobileweb-adapter](https://github.com/dsh-external/dsh-mobileweb-adapter) | 手机 Web 适配器：让 Web GUI 在手机上可用（⚠️ dsh-external，公开性待核实） |  |  |
-| [dsh-mobile](https://github.com/dsh-external/dsh-mobile) | 移动端客户端（⚠️ dsh-external，公开性待核实） | 12 |  |
-| [dsh-android](https://github.com/dsh-external/dsh-android) | 在 Android 上运行 dsh（⚠️ dsh-external，公开性待核实） |  |  |
+| [dsh-mobileweb-adapter](https://github.com/dsh-external/dsh-mobileweb-adapter) | 手机 Web 适配器：让 Web GUI 在手机上可用（⚠️ dsh-external，已删除） |  |  |
+| [dsh-mobile](https://github.com/lehhair/dsh-mobile) | 移动端客户端（⚠️ dsh-external，公开性待核实） | 12 |  |
+| [dsh-android](https://github.com/dsh-external/dsh-android) | 在 Android 上运行 dsh（⚠️ dsh-external，已删除） |  |  |
+| [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) | Rust/ratatui 编写的 DSH 终端 TUI | 25 | `dsh plugin add github:openma-ai/deepseek-harness-tui` |
 
 </details>
 
@@ -258,18 +259,18 @@ Expand any category to browse all plugins inline — no need to leave this page.
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
-| [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | AgentTeams 多智能体团队协作 | 302 | `dsh plugin add dsh-agent-teams` |
-| [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | 把 UltraCode 式多 Agent 调度带给 DSH：可生成/保存/治理/观察/恢复的 Workflow 层 | 55 | `dsh plugin add @dsh-external/workflow` |
+| [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | AgentTeams 多智能体团队协作 | 312 | `dsh plugin add dsh-agent-teams` |
+| [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | 把 UltraCode 式多 Agent 调度带给 DSH：可生成/保存/治理/观察/恢复的 Workflow 层 | 56 | `dsh plugin add @dsh-external/workflow` |
 | [dsh-meta-orchestrator](https://github.com/jiruidai/dsh-meta-orchestrator) | 模型原生 meta-agent：运行时合成任务专属工作流并协调工具/子代理 | 3 | `dsh plugin add dsh-meta-orchestrator` |
 | [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) | 跨会话消息互发：本机任意会话像 Claude Code 一样互发消息 | 2 | `dsh plugin add @dsh-crosstalk/bundle` |
 | [dsh-agent-messaging](https://github.com/happyren/dsh-agent-messaging) | 跨会话 agent-to-agent 消息投递（按会话名寻址） | 4 | `dsh plugin add dsh-agent-messaging` |
-| [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | 跨实例消息/事件交接（interconnect 服务 + 工具） | 26 | `dsh plugin add dsh-interconnect` |
+| [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | 跨实例消息/事件交接（interconnect 服务 + 工具） | 27 | `dsh plugin add dsh-interconnect` |
 | [dsh-session-hub](https://github.com/Asaiuta/dsh-session-hub) | 多服务器 DSH 会话聚合与原生操控（hub 网关 + 官方 UI 桥） | 3 | `dsh plugin add dsh-session-hub` |
 | [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) | 可配置子代理 profiles + 实时工具调用/token 显示 + 子会话跳转 | 7 | `dsh plugin add @huanlin/dsh-plugin-yet-another-subagent` |
-| [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) | 双模型 plan/execute 路由（planner 想、executor 做）⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-a2a](https://github.com/dsh-external/dsh-a2a) | Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 | 4 |  |
-| [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) | 子代理树可视化 ⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) | 团队协作（cordis）⚠️ dsh-external，公开性待核实 |  |  |
+| [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) | 双模型 plan/execute 路由（planner 想、executor 做）⚠️ dsh-external，已删除 |  |  |
+| [dsh-a2a](https://github.com/dpskh/dsh-a2a) | Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 | 4 |  |
+| [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) | 子代理树可视化 ⚠️ dsh-external，已删除 |  |  |
+| [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) | 团队协作（cordis）⚠️ dsh-external，已删除 |  |  |
 
 </details>
 
@@ -278,11 +279,11 @@ Expand any category to browse all plugins inline — no need to leave this page.
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
-| [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） | 76 |  |
+| [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） | 82 |  |
 | [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：模型决定何时压缩（移植自 billion-context-pi） | 12 |  |
 | [dsh-memory](https://github.com/Jesse-njx/dsh-memory) | 基于无损会话日志的引用式记忆（事实带 sessionId/eventRange 引用） | 2 | `dsh plugin add @dsh-memory/bundle` |
 | [dsh-memory](https://github.com/ben7am1n/dsh-memory) | 跨会话 SQLite 持久记忆 | 1 | `dsh plugin add dsh-memory` |
-| [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 本地三层记忆（Runtime Memory/可检索文档/受监督 Memory Spaces） | 25 | `dsh plugin add dsh-mnemon` |
+| [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 本地三层记忆（Runtime Memory/可检索文档/受监督 Memory Spaces） | 26 | `dsh plugin add dsh-mnemon` |
 | [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) | 给所有 AI 工具共用的一层记忆（Context Bundle 注入 + MCP 工具 + 线程捕获） | 5 | `dsh plugin add nowledge-mem-deepseek-harness` |
 | [dsh-plugin-meta-memory](https://github.com/YYTbit/dsh-plugin-meta-memory) | 结构化长期记忆系统 | 2 | `dsh plugin add dsh-plugin-meta-memory` |
 | [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) | 从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5） | 2 | `dsh plugin add @dsh-external/dsh-kb-sieve` |
@@ -291,13 +292,13 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [context-vista](https://github.com/GooodWei/context-vista) | `/context` 命令 + 环形图实时展示上下文 token 用量与费用 | 4 | `dsh plugin add context-vista` |
 | [distill](https://github.com/LoserFox/distill) | 自动对话蒸馏：后台 subagent 反省 + 技能 create/update | 17 | `dsh plugin add @loserfox/distill` |
 | [dsh-auto-compact](https://github.com/wangxiang0605qvq/dsh-auto-compact) | compact_now 工具，回合结束自动压缩上下文 |  |  |
-| [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) | 上下文管理：节省、注意力优化、压缩档案馆 ⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-context](https://github.com/bowenliang123/dsh-context) | 上下文洞察面板：展示模型上下文窗口的构成与演化 | 38 | `dsh plugin add dsh-context` |
+| [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) | 上下文管理：节省、注意力优化、压缩档案馆 ⚠️ dsh-external，已删除 |  |  |
+| [dsh-context](https://github.com/bowenliang123/dsh-context) | 上下文洞察面板：展示模型上下文窗口的构成与演化 | 40 | `dsh plugin add dsh-context` |
 | [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) | 对话回退：基于持久 Change Ledger 回滚会话与工作区状态 | 50 | `dsh plugin add @dsh-external/turn-rewind` |
 | [dsh-undo](https://github.com/LingLambda/dsh-undo) | 上下文 undo/redo：回退到上一个已完成步骤并恢复 | 3 | `dsh plugin add dsh-undo` |
 | [dsh-recall](https://github.com/Mongfayi/dsh-recall) | 消息撤回：每条用户消息一个撤销按钮，删除该轮及其后内容（不改代码） | 3 | `dsh plugin add dsh-recall` |
-| [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) | `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行 | 6 | `dsh plugin add @dsh-external/dsh-sidechain` |
-| [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) | 基于分支的消息编辑、reroll、重试与版本时间线 | 20 | `dsh plugin add dsh-message-edit` |
+| [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) | `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行 | 7 | `dsh plugin add @dsh-external/dsh-sidechain` |
+| [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) | 基于分支的消息编辑、reroll、重试与版本时间线 | 21 | `dsh plugin add dsh-message-edit` |
 | [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) | 跨 dsh/Codex/Claude/pi/OpenCode 会话的无索引全文搜索 | 2 |  |
 | [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话 | 29 | `dsh plugin add dsh-chat-import` |
 | [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH | 3 | `dsh plugin add dsh-claude-move` |
@@ -309,9 +310,9 @@ Expand any category to browse all plugins inline — no need to leave this page.
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
-| [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1664 | `dsh plugin add @liustack/modlens` |
-| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts | 401 | `dsh plugin add @dsh-external/dsh-vision-toolkit` |
-| [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) | 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） | 882 |  |
+| [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1736 | `dsh plugin add @liustack/modlens` |
+| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts | 409 | `dsh plugin add @dsh-external/dsh-vision-toolkit` |
+| [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) | 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） | 887 |  |
 | [dsh-vision](https://github.com/william-jin-cmu/dsh-vision) | view_image 工具桥接任意 OpenAI 兼容 VLM（默认智谱免费档） | 23 |  |
 | [dsh-vision-LMstudio](https://github.com/TiankunDai/dsh-vision-LMstudio) | 通过 LM Studio 调用本地视觉模型 | 1 |  |
 | [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | DeepSeek 大脑 + 自动识图（图片经 Qwen VLM 转文字后作答） | 8 | `dsh plugin add dsh-vision-proxy` |
@@ -325,26 +326,26 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-mobile-control](https://github.com/PangYiMing/dsh-mobile-control) | 操控手机（ADB/iOS） | 2 | `dsh plugin add dsh-mobile-control` |
 | [dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 原生鸿蒙设备桥：hdc 截图-看图-装包-验证闭环调试 | 5 | `dsh plugin add dsh-hdc-bridge` |
 | [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) | provider 无关的 AIGC HTTP 桥 + 自由画布 + ffmpeg 后处理 | 6 | `dsh plugin add @huanlin/dsh-plugin-aigc-canvas` |
-| [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） | 108 | `dsh plugin add dsh-vision-router` |
+| [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） | 111 | `dsh plugin add dsh-vision-router` |
 
 </details>
 
 <details>
-<summary>🔁 Workflow / Automation · 20</summary>
+<summary>🔁 Workflow / Automation · 21</summary>
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | 自适应深度研究编排器（基于官方 workflow 引擎） | 12 | `dsh plugin add @dsh-external/dsh-deep-research` |
-| [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) | 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） | 4 | `dsh plugin add @deepseek-ai/dsh-deepresearch` |
+| [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) | 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） | 5 | `dsh plugin add @deepseek-ai/dsh-deepresearch` |
 | [dsh-loop](https://github.com/vlln/dsh-loop) | 定时循环：`/loop` 命令 + loop 工具 + 活动状态条 | 3 | `dsh plugin add @dsh-external/dsh-loop` |
 | [dsh-sentinel](https://github.com/fuhefei/dsh-sentinel) | 条件驱动唤醒：file/command/http/process/webhook 持久监视触发 agent | 7 | `dsh plugin add @dsh-external/dsh-sentinel` |
-| [dsh-automation](https://github.com/titanwings/dsh-automation) | 定时任务：Coding 任务按计划在全新 Agent Session 中运行 | 37 | `dsh plugin add @dsh-external/dsh-automation` |
+| [dsh-automation](https://github.com/titanwings/dsh-automation) | 定时任务：Coding 任务按计划在全新 Agent Session 中运行 | 39 | `dsh plugin add @dsh-external/dsh-automation` |
 | [dsh-routines](https://github.com/Jesse-njx/dsh-routines) | cron 定时 Agent：按计划跑 prompt 并把摘要送到你所在处 | 1 | `dsh plugin add @dsh-routines/bundle` |
 | [dsh-plannotator](https://github.com/titanwings/dsh-plannotator) | 计划批注：选中计划原文逐条批注并回送结构化反馈 | 5 | `dsh plugin add @dsh-external/dsh-plannotator` |
 | [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) | 发现问题→修复→复查的对抗式闭环（基于官方 workflow 引擎） | 5 | `dsh plugin add @dsh-external/dsh-inspect` |
-| [dsh-advisor](https://github.com/btspoony/dsh-advisor) | 副模型每轮被动审查并注入见解 | 9 | `dsh plugin add dsh-advisor` |
-| [mstar-harness](https://github.com/btspoony/mstar-harness) | Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 | 45 |  |
-| [dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) | 基于角色的模型重试/备用策略 | 4 | `dsh plugin add dsh-llm-fallbacks` |
+| [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) | 副模型每轮被动审查并注入见解 | 9 | `dsh plugin add dsh-advisor` |
+| [mstar-harness](https://github.com/btspoony/mstar-harness) | Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 | 46 |  |
+| [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) | 基于角色的模型重试/备用策略 | 4 | `dsh plugin add dsh-llm-fallbacks` |
 | [dsh-polyglot](https://github.com/Jesse-njx/dsh-polyglot) | 模型切换器：任意 OpenAI 兼容端点 + 免费/低价 DeepSeek 预设 + 限流自动回退 | 1 | `dsh plugin add @dsh-polyglot/bundle` |
 | [dsh-track](https://github.com/fakechris/dsh-track) | 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储 | 6 | `dsh plugin add @deepseek-ai/dsh-track` |
 | [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay) | 录制 macOS 桌面工作流演示并转成 agent 技能（orr_* 工具） | 7 | `dsh plugin add dsh-record-replay` |
@@ -354,11 +355,12 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) | 手动审批模式（Manual/Ask Mode） | 1 | `dsh plugin add dsh-tool-approval` |
 | [dsh-tiered-approval](https://github.com/Elaina-real/dsh-tiered-approval) | 分层自动审查：静态规则 + LLM 审查 + 人工兜底 | 2 | `dsh plugin add dsh-tiered-approval` |
 | [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | 事件流审计面板：观察事件类型/分发模式/计数，帮插件作者理解内部 | 1 | `dsh plugin add @dsh-external/dsh-event-auditor` |
+| [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | 自动续传：网络中断后自动发「继续」恢复请求 | 15 | `dsh plugin add github:HsiangNianian/dsh-auto-continue` |
 
 </details>
 
 <details>
-<summary>📡 Notifications / Channels · 18</summary>
+<summary>📡 Notifications / Channels · 17</summary>
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
@@ -366,20 +368,19 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram 运行时适配器（per-chat 会话、allowlist 认证） | 1 | `dsh plugin add dsh-telegram` |
 | [DSH-Telegram-Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) | 通过 Telegram 远程对话并接收通知 | 5 | `dsh plugin add dsh-telegram-relay` |
 | [dsh-chatnode-wechat](https://github.com/Jesse-njx/dsh-chatnode-wechat) | 通过 iLink 网关在微信里与 DSH agent 聊天/监控/审批 | 2 | `dsh plugin add @dsh-cowork/chatnode-wechat` |
-| [dsh-lark](https://github.com/Roy-oss1/dsh-lark) | 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片 | 2 | `dsh plugin add @dsh-contrib/dsh-lark-channel` |
+| [dsh-lark](https://github.com/Roy-oss1/dsh-lark) | 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片（已删除） | 2 | `dsh plugin add @dsh-contrib/dsh-lark-channel` |
 | [dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) | 双向飞书控制器 | 7 | `dsh plugin add dsh-lark-bridge` |
 | [dsh-onlyne](https://github.com/dbydd/dsh-onlyne) | IM 网关：从 dsh 会话收发 QQ/微信/飞书/Telegram 消息 | 2 |  |
-| [dsh-notification](https://github.com/omdsh-dev/dsh-notification) | 回合完成桌面通知，按结果分控 + 关键词过滤 | 45 | `dsh plugin add dsh-notification` |
+| [dsh-notification](https://github.com/omdsh-dev/dsh-notification) | 回合完成桌面通知，按结果分控 + 关键词过滤 | 47 | `dsh plugin add dsh-notification` |
 | [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) | Windows 通知（零依赖） | 3 |  |
 | [dsh-win-notify](https://github.com/MuziIsabel/dsh-win-notify) | Windows toast 通知（任务完成带声音） | 4 | `dsh plugin add dsh-win-notify` |
 | [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) | 桌面通知提醒 | 12 | `dsh plugin add @bill9109/dsh-web-ui-notify` |
-| [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) | 会话完成等四种状态通知，支持浏览器提示 | 6 | `dsh plugin add @dingyi222666/dsh-session-notification` |
+| [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) | 会话完成等四种状态通知，支持浏览器提示 | 7 | `dsh plugin add @dingyi222666/dsh-session-notification` |
 | [dsh-ssh](https://github.com/UynajGI/dsh-ssh) | SSH 远程执行（ProxyJump 链、SFTP 文件系统、PTY） | 4 |  |
 | [dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | 通用 webhook 接收器：POST /hook/:channel 唤醒 per-channel agent | 1 | `dsh plugin add dsh-webhook-bridge` |
-| [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) | 从 Web GUI 一键在 VS Code 中打开工作区目录 | 41 | `dsh plugin add dsh-open-in-vscode` |
-| [dsh-share](https://github.com/hellodigua/dsh-share) | 一键分享你的对话 | 18 | `dsh plugin add @dsh-external/dsh-share` |
+| [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) | 从 Web GUI 一键在 VS Code 中打开工作区目录 | 42 | `dsh plugin add dsh-open-in-vscode` |
+| [dsh-share](https://github.com/hellodigua/dsh-share) | 一键分享你的对话 | 19 | `dsh plugin add @dsh-external/dsh-share` |
 | [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) | 分享任意段落的对话 | 1 | `dsh plugin add @bill9109/dsh-conversation-share` |
-| [dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) | BitFun 与 DSH 的 ACP 交互对接 | 9 | `dsh plugin add dsh-acp-for-bitfun` |
 
 </details>
 
@@ -388,7 +389,7 @@ Expand any category to browse all plugins inline — no need to leave this page.
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
-| [dsh-browser](https://github.com/Lum1104/dsh-browser) | Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） | 133 |  |
+| [dsh-browser](https://github.com/Lum1104/dsh-browser) | Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） | 140 |  |
 | [dsh-browser-control](https://github.com/PangYiMing/dsh-browser-control) | CDP/Playwright 操控浏览器 | 1 | `dsh plugin add dsh-browser-control` |
 | [ego-browser](https://github.com/Fisfzy/ego-browser) | 把 ego-lite（给 AI Agent 的 Chromium）接入 DSH，13 个结构化 ego_* 工具 | 13 |  |
 | [dsh-better-browser](https://github.com/titanwings/dsh-better-browser) | 通过 Kimi WebBridge 让 Agent 操作用户已登录浏览器（13 个工具） | 7 | `dsh plugin add @dsh-external/dsh-better-browser` |
@@ -397,29 +398,28 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [DSH-Chrome-devtools](https://github.com/yuzi-ska/DSH-Chrome-devtools) | 基于 Chrome DevTools MCP 的真实 Chrome 控制 | 1 | `dsh plugin add dsh-chrome-devtools` |
 | [dsh-playwright-cli](https://github.com/mitao-su/dsh-playwright-cli) | 包装 Playwright CLI：装浏览器、跑测试、从 agent 循环打开 HTML 报告 | 2 | `dsh plugin add dsh-playwright-cli` |
 | [deepseek-pp](https://github.com/zhu1090093659/deepseek-pp) | 浏览器扩展 AI Agent 工作区，内置 MCP 与记忆 | 1558 |  |
-| [dsh-webfetch](https://github.com/withlovehub/dsh-webfetch) | 零依赖 webfetch MCP server（robots 合规、SSRF 防护） | 2 |  |
 | [dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方接入内置 web_search | 2 | `dsh plugin add @yangzhe1003/dsh-web-search-firecrawl` |
 | [dsh-web-search-tavily](https://github.com/crayonlu/dsh-web-search-tavily) | Tavily 搜索提供方（免 DeepSeek key） | 3 |  |
 | [dsh-tavily-search](https://github.com/zhouzhencheng07/dsh-tavily-search) | 免 key Tavily 搜索工具 | 2 | `dsh plugin add dsh-tavily-search` |
 | [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) | 增强持久搜索（多引擎 + SQLite/LRU 缓存 + Playwright 渲染） | 7 | `dsh plugin add dsh-web-search-pro` |
 | [dsh-all-search](https://github.com/RealAlexandreAI/dsh-all-search) | AnySearch 网页搜索提供方（ctx.web） | 1 | `dsh plugin add dsh-all-search` |
-| [modsearch](https://github.com/liustack/modsearch) | CLI 搜索工具：把搜索查询转结构化 web 证据 JSON | 103 | `dsh plugin add @liustack/modsearch` |
+| [modsearch](https://github.com/liustack/modsearch) | CLI 搜索工具：把搜索查询转结构化 web 证据 JSON | 104 | `dsh plugin add @liustack/modsearch` |
+| [argo](https://github.com/taxueseek/argo) | 为 agent 打造的多语言搜索工具（中文/英文/学术/代码/购物/金融/新闻/百科） | 77 | `dsh plugin add github:taxueseek/argo` |
 
 </details>
 
 <details>
-<summary>🏗️ Infra / Plugin Mgmt · 32</summary>
+<summary>🏗️ Infra / Plugin Mgmt · 33</summary>
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
-| [plugin-registry](https://github.com/dsh-external/plugin-registry) | 第三方本地插件系统：`dsh.plugin.json` 协议 + install/enable/disable + Web 面板（公开） | 40 |  |
 | [plugin-registry](https://github.com/vlln/plugin-registry) | 插件管理控制台：浏览器面板管理官方 repository 插件 + 开发引导 | 40 |  |
 | [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) | 离线容忍的注册表：从 awesome 列表/GitHub topics/npm 发现并去重 DSH 插件 | 1 |  |
 | [dsh-hub](https://github.com/omdsh-dev/dsh-hub) | OMDSH 社区扩展 hub（基于官方 contracts） | 4 | `dsh plugin add @omdsh/dsh-hub` |
 | [DSH-plugin-switch](https://github.com/Nexus-Aethra/DSH-plugin-switch) | 插件市场：浏览/搜索/安装 GitHub 项目，自动识别 plugin/skill | 2 | `dsh plugin add dsh-plugin-switch` |
 | [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) | 把 DSH 快速接入 GitHub 插件生态的市场插件 | 6 | `dsh plugin add dsh-plugin-installer` |
-| [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） | 39 | `dsh plugin add @dsh-external/dsh-super-injector` |
-| [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop | 46 |  |
+| [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） | 48 | `dsh plugin add @dsh-external/dsh-super-injector` |
+| [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop | 47 |  |
 | [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) | 插件健康检查：扫描清单协议/patch 格式/构建陷阱/hub 状态 | 17 | `dsh plugin add @deepseek-ai/dsh-plugin-check` |
 | [dsh-plugin-doctor](https://github.com/lin-cheng-lab/dsh-plugin-doctor) | 插件体检：安装前检查 peer 版本兼容性 | 1 | `dsh plugin add dsh-plugin-doctor` |
 | [dsh-doctor](https://github.com/asdf17128/dsh-doctor) | profile 健康检查：找 patch 静默破坏的配置/死 patch/工具名冲突 | 1 |  |
@@ -444,11 +444,13 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) | Multica 的 DSH runtime 桥接（stdio JSONL 协议） | 34 | `dsh plugin add @multica-ai/dsh-runtime` |
 | [session-teleport](https://github.com/omdsh-dev/session-teleport) | PostgreSQL 单写者会话交接服务 | 2 | `dsh plugin add @mattheliu/session-teleport` |
 | [session-persistence-rdb](https://github.com/morlay/session-persistence-rdb) | session 关系型数据库持久化 | 4 | `dsh plugin add @morlay/session-persistence-rdb` |
+| [dsh-market](https://github.com/dsh-market/dsh-market) | DSH 可视化插件市场：浏览/搜索/一键安装 | 221 | `dsh plugin add github:dsh-market/dsh-market` |
+| [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) | dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin 目录/安装/卸载 | 42 | `dsh plugin add github:Sanqi-normal/dsh-webui-market-plugin` |
 
 </details>
 
 <details>
-<summary>🎮 Fun / Other · 28</summary>
+<summary>🎮 Fun / Other · 31</summary>
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
@@ -457,13 +459,13 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) | 自走棋：人机对战或双 AI 对弈 | 3 | `dsh plugin add @deepseek-ai/dsh-auto-chess` |
 | [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) | 模型生成时弹出小游戏菜单（wordle/消消乐，可扩展） | 5 | `dsh plugin add @huanlin/dsh-plugin-d399` |
 | [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) | 全手绘像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心） | 30 |  |
-| [whale-girl](https://github.com/vlln/whale-girl) | 桌面宠物鲸鱼娘（QQ 宠物形态，可拖拽/投喂/玩耍） | 159 | `dsh plugin add whale-girl` |
+| [whale-girl](https://github.com/vlln/whale-girl) | 桌面宠物鲸鱼娘（QQ 宠物形态，可拖拽/投喂/玩耍） | 160 | `dsh plugin add whale-girl` |
 | [dsh-pixel-whale](https://github.com/yoke233/dsh-pixel-whale) | 活泼像素鲸鱼运行状态伴侣 | 1 | `dsh plugin add dsh-pixel-whale` |
 | [dsh-blue-whale-maid](https://github.com/yuxino/dsh-blue-whale-maid) | 蓝鲸女仆桌面像素宠物 | 3 | `dsh plugin add dsh-blue-whale-maid` |
-| [deepseek-pet](https://github.com/keleus/deepseek-pet) | 在 DSH 上养一只大蓝鲸 | 15 | `dsh plugin add deepseek-pet` |
-| [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) | 用户与 agent 双向表情贴纸互动 | 15 | `dsh plugin add @dsh-external/dsh-stickers` |
+| [deepseek-pet](https://github.com/keleus/deepseek-pet) | 在 DSH 上养一只大蓝鲸 | 18 | `dsh plugin add deepseek-pet` |
+| [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) | 用户与 agent 双向表情贴纸互动 | 16 | `dsh plugin add @dsh-external/dsh-stickers` |
 | [dsh-emoji](https://github.com/hellodigua/dsh-emoji) | 为 AI 回复自动添加表情 | 17 | `dsh plugin add @dsh-external/dsh-emoji` |
-| [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 2005 中文站点风格整活广告（侧栏/信息流/弹窗，素材全虚构） | 388 | `dsh plugin add @dsh-external/dsh-ads` |
+| [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 2005 中文站点风格整活广告（侧栏/信息流/弹窗，素材全虚构） | 396 | `dsh plugin add @dsh-external/dsh-ads` |
 | [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) | 股票行情数据插件（整活向） | 11 | `dsh plugin add dsh-stock-market` |
 | [dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) | 侧栏短视频：原生播放器、系列导航、历史回放 | 2 | `dsh plugin add dsh-douyin` |
 | [deepseek-manners](https://github.com/Moeblack/deepseek-manners) | 每次消息后注入感谢语，做个有礼貌的人 | 10 | `dsh plugin add deepseek-manners` |
@@ -471,39 +473,41 @@ Expand any category to browse all plugins inline — no need to leave this page.
 | [dsh-fun-typewriter](https://github.com/omdsh-dev/dsh-fun-typewriter) | WebAudio 打字机氛围音效（零音频资源） | 3 | `dsh plugin add @deepseek-ai/dsh-fun-typewriter` |
 | [dsh-daily-fortune](https://github.com/omdsh-dev/dsh-daily-fortune) | 每日运势：观音签、塔罗、每日一句 | 3 | `dsh plugin add @deepseek-ai/dsh-daily-fortune` |
 | [dsh-plugin-spur](https://github.com/HuanLinOTO/dsh-plugin-spur) | 挂在聊天流里的辫子，抓住甩一甩给 agent 发「去干活」 | 3 | `dsh plugin add @huanlin/dsh-plugin-spur` |
-| [dsh-toy](https://github.com/c3ll256/dsh-toy) | 连接小型玩具到 DSH（Toy Control Protocol） | 38 | `dsh plugin add dsh-toy` |
+| [dsh-toy](https://github.com/c3ll256/dsh-toy) | 连接小型玩具到 DSH（Toy Control Protocol） | 43 | `dsh plugin add dsh-toy` |
 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | 费曼学习模式：教→讲回→判→再解释，渲染为富 HTML 课程卡 | 4 | `dsh plugin add dsh-learn-everything` |
 | [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) | OpenMAIC 教学：课堂、幻灯片、交互组件、苏格拉底式教学 | 8 | `dsh plugin add @openmaic/dsh-openmaic` |
 | [dsh-scholar](https://github.com/lzszq/dsh-scholar) | 学术助手插件 | 15 | `dsh plugin add @dsh-scholar/research-plugin` |
 | [dsh-101](https://github.com/bill9109/dsh-101) | DSH 文档阅读模式 | 3 | `dsh plugin add @dsh-external/dsh-101` |
 | [dsh-reasoning-translator](https://github.com/pinkllo/dsh-reasoning-translator) | 让模型的思维链用你的语言输出 | 2 | `dsh plugin add dsh-reasoning-translator` |
-| [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | OpenPencil 设计预览与编辑（Agent 操作真实设计画布） | 74 | `dsh plugin add @zseven-w/dsh-openpencil` |
 | [dsh-director-toolkit](https://github.com/lhmd/dsh-director-toolkit) | 3D 艺术家/技术美术方向包：Blender/Three.js/Houdini/C4D 方向指引 | 7 | `dsh plugin add @lhmd/dsh-director-toolkit` |
 | [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) | Xcode AI 集成：26 个 Xcode MCP 工具 + Apple 平台技能 | 1 | `dsh plugin add dsh-apple-mode` |
+| [notes](https://github.com/zhaoolee/notes) | 开源版锤子便签：导出 DSH 会话为便签图片，支持 skill 调用 ⚠️ 无 license 文件 | 142 |  |
+| [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) | DSH 会话费用统计（本会话/当日/历史 + 官方价格同步） | 31 | `dsh plugin add github:Han-1413141/dsh-cost-meter` |
+| [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) | persona 驱动的 UX 走查：扫描 React/TS 源码找 UX 问题 | 18 | `dsh plugin add github:DietCokewithSugar/dsh-user-experience` |
+| [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) | DeepSeek 账户余额与会话成本显示 | 13 | `dsh plugin add github:Ghost011118/dsh-balance-meter` |
 
 </details>
 
 <details>
-<summary>🏛️ Official & Meta · 17</summary>
+<summary>🏛️ Official & Meta · 16</summary>
 
 | Plugin | Description | ⭐ | Install |
 |---|---|---|---|
-| [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 107568 |  |
-| [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5850 |  |
-| [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2326 |  |
-| [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) | 「30 秒找到适合你的插件」，带场景说明 + 505 全量快照 | 132 |  |
-| [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) | DSH 生态精选：插件/工具/基础设施 | 454 |  |
-| [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 928 |  |
-| [Alex-Yanggg/awesome-DSH-plugin](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | 覆盖生产力/扩展/调试/自定义开发的分类 catalog | 61 |  |
-| [dsh-external/hub](https://github.com/dsh-external/hub) | 社区组织级索引/目录元仓库（⚠️ 私有，白名单可见） |  |  |
-| [dsh-external/plugin-registry](https://github.com/dsh-external/plugin-registry) | 第三方插件系统：`dsh.plugin.json` 协议（公开） | 40 |  |
-| [dsh-external/marisa](https://github.com/dsh-external/marisa) | 「寄生式」外部插件管理器 `dshx`（⚠️ 私有，白名单可见） |  |  |
-| [dsh-external/toybox](https://github.com/dsh-external/toybox) | 插件玩具箱：静态 `.dsh-plugin` 格式的技能/MCP 插件收藏（公开） |  |  |
+| [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 109475 |  |
+| [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5853 |  |
+| [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2519 |  |
+| [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) | 「30 秒找到适合你的插件」，带场景说明 + 505 全量快照 | 139 |  |
+| [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) | DSH 生态精选：插件/工具/基础设施 | 465 |  |
+| [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 942 |  |
+| [Alex-Yanggg/awesome-DSH-plugin](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | 覆盖生产力/扩展/调试/自定义开发的分类 catalog | 62 |  |
+| [dsh-external/hub](https://github.com/dsh-external/hub) | 社区组织级索引/目录元仓库（⚠️ 私有，白名单可见） （已删除） |  |  |
+| [dsh-external/marisa](https://github.com/dsh-external/marisa) | 「寄生式」外部插件管理器 `dshx`（⚠️ 私有，白名单可见） （已删除） |  |  |
+| [dsh-external/toybox](https://github.com/dsh-external/toybox) | 插件玩具箱：静态 `.dsh-plugin` 格式的技能/MCP 插件收藏（公开） （已删除） |  |  |
 | [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) | 第三方 Harness：Python 库 + dsh CLI + MCP server + SKILL.md | 40 |  |
 | [vvlife/whalehub-dsh](https://github.com/vvlife/whalehub-dsh) | 第三方插件商店/中心 | 4 |  |
-| [dsh-plugin-guide](https://github.com/dsh-external/dsh-plugin-guide) | DSH 插件开发指南：从零到精通 ⚠️ 公开性待核实 |  |  |
-| [dsh-cordis-rocks](https://github.com/dsh-external/dsh-cordis-rocks) | 16 章可逆 Cordis 配套教程 ⚠️ 公开性待核实 |  |  |
-| [dsh-cordis-examples](https://github.com/dsh-external/dsh-cordis-examples) | 最小原生 DSH/Cordis 扩展示例 ⚠️ 公开性待核实 |  |  |
+| [dsh-plugin-guide](https://github.com/dsh-external/dsh-plugin-guide) | DSH 插件开发指南：从零到精通 ⚠️ 已删除 |  |  |
+| [dsh-cordis-rocks](https://github.com/dsh-external/dsh-cordis-rocks) | 16 章可逆 Cordis 配套教程 ⚠️ 已删除 |  |  |
+| [dsh-cordis-examples](https://github.com/dsh-external/dsh-cordis-examples) | 最小原生 DSH/Cordis 扩展示例 ⚠️ 已删除 |  |  |
 | [plugin-template](https://github.com/omdsh-dev/plugin-template) | 插件模板仓库（基于 turtle-ui） | 5 | `dsh plugin add @your-scope/dsh-plugin-template` |
 
 </details>

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,16 +49,16 @@
 
 | # | 插件 | 描述 | ⭐ |
 |---|---|---|---|
-| 1 | [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 107568 |
-| 2 | [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5850 |
-| 3 | [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4287 |
-| 4 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2397 |
-| 5 | [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2326 |
-| 6 | [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1664 |
+| 1 | [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 109475 |
+| 2 | [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5853 |
+| 3 | [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4668 |
+| 4 | [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2519 |
+| 5 | [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2484 |
+| 6 | [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1736 |
 | 7 | [deepseek-pp](https://github.com/zhu1090093659/deepseek-pp) | 浏览器扩展 AI Agent 工作区，内置 MCP 与记忆 | 1558 |
-| 8 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1120 |
-| 9 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 988 |
-| 10 | [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 928 |
+| 8 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1157 |
+| 9 | [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 1065 |
+| 10 | [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 942 |
 
 <!-- hot:end -->
 
@@ -115,9 +115,9 @@
 | [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) | 结构化 test_run：自动探测 vitest/jest/pytest/node:test 并解析失败摘要 | 2 | `dsh plugin add dsh-test-runner` |
 | [dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) | 密钥/危险模式扫描（API key/token/私钥脱敏，零依赖） | 1 | `dsh plugin add dsh-security-scan` |
 | [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) | 按 agent 的按需工具发现 + 渐进式 schema 披露 | 2 | `dsh plugin add @deepseek-ai/dsh-tool-search` |
-| [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) | 用 Monaco 编辑器创建/管理沙箱化自定义 JS 工具 | 23 | `dsh plugin add dsh-custom-tool` |
+| [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) | 用 Monaco 编辑器创建/管理沙箱化自定义 JS 工具 | 24 | `dsh plugin add dsh-custom-tool` |
 | [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) | 自动识别并解码 Bash 输出编码（UTF-16LE/UTF-8/GBK），修中文乱码 | 7 |  |
-| [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | Codex 风格 `@file` 文件引用，输入框里直接搜索并引用工作区文件 | 187 | `dsh plugin add dsh-at-file` |
+| [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) | Codex 风格 `@file` 文件引用，输入框里直接搜索并引用工作区文件 | 198 | `dsh plugin add dsh-at-file` |
 | [dsh-wikilink](https://github.com/zhaoscsc/dsh-wikilink) | Obsidian 风格 `[[wikilink]]` 提及：模糊搜索笔记标题并附加内容 | 3 | `dsh plugin add dsh-wikilink` |
 | [dsh-safe-delete](https://github.com/Qintsg/dsh-safe-delete) | 安全删除：移入回收站/暂存区而非永久删除，支持恢复 | 3 |  |
 | [dsh-bisect-debug](https://github.com/PangYiMing/dsh-bisect-debug) | 二分法定位 bug 根因（代码/边界/commit） | 1 | `dsh plugin add dsh-bisect-debug` |
@@ -125,8 +125,8 @@
 | [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) | 让 AI 帮你连数据库、写 SQL | 25 | `dsh plugin add @deepseek-ai/dsh-data-agent` |
 | [dsh-openapi](https://github.com/Degurechaff57/dsh-openapi) | Safe OpenAPI 3.x 发现与 API 调用工具 | 4 | `dsh plugin add dsh-openapi` |
 | [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) | 暴露 run_python / run_node 工具，可配置解释器路径 | 6 | `dsh plugin add @huanlin/dsh-plugin-interpreters` |
-| [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) | doc_read/doc_write：以有界、单元格寻址方式读写 xlsx/pdf/docx/pptx/ipynb | 2 |  |
-| [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) | 向模型暴露 MineRU 文档解析工具 | 18 | `dsh plugin add @huanlin/dsh-plugin-mineru` |
+| [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) | doc_read/doc_write：以有界、单元格寻址方式读写 xlsx/pdf/docx/pptx/ipynb | 3 |  |
+| [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) | 向模型暴露 MineRU 文档解析工具 | 20 | `dsh plugin add @huanlin/dsh-plugin-mineru` |
 | [dsh-plugin-sleep](https://github.com/HuanLinOTO/dsh-plugin-sleep) | 暴露单个 `sleep` 工具，让模型按需暂停（支持取消） | 6 | `dsh plugin add @huanlin/dsh-plugin-sleep` |
 | [dsh-port-guard](https://github.com/PangYiMing/dsh-port-guard) | 端口占用处置（复用/切换/精确 kill） | 1 | `dsh plugin add dsh-port-guard` |
 | [dsh-scout](https://github.com/omdsh-dev/dsh-scout) | 只读环境探测：运行环境/版本/资源/端口/服务/硬件/工作区 | 2 | `dsh plugin add @deepseek-ai/dsh-tool-scout` |
@@ -134,7 +134,7 @@
 </details>
 
 <details>
-<summary>🧩 技能类 Skills · 16</summary>
+<summary>🧩 技能类 Skills · 17</summary>
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
@@ -142,18 +142,19 @@
 | [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) | 把已有 Agent Skills（Claude/Codex/Cursor/Gemini 的 SKILL.md）带进 DSH，渐进式索引 + 按需加载 | 2 | `dsh plugin add @dsh-skillport/bundle` |
 | [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) | 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索/安装/生命周期管理 | 2 | `dsh plugin add dsh-find-skill` |
 | [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) | 构建与测试 DSH 插件的 Agent 技能（脚手架到测试分层） | 7 |  |
-| [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | 五阶段「书→技能」长任务（抓取→解析→理解→生成→安装）+ 3 个人工关卡 | 3 | `dsh plugin add dsh-book2skill` |
+| [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | 五阶段「书→技能」长任务（抓取→解析→理解→生成→安装）+ 3 个人工关卡 | 4 | `dsh plugin add dsh-book2skill` |
 | [dsh-superpowers](https://github.com/codeAnqiang-ma/dsh-superpowers) | Superpowers（obra/superpowers）作为 DSH 插件：方法论技能 + 会话引导 | 3 | `dsh plugin add dsh-superpowers` |
 | [dsh-plugin-code-review](https://github.com/YYTbit/dsh-plugin-code-review) | 结构化代码审查技能（YYTbit 系列） | 1 | `dsh plugin add dsh-plugin-code-review` |
 | [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) | 增量 diff 审查：checkpoint 队列 + Web 面板 + 审查意见注入 agent | 2 | `dsh plugin add @dsh-plugin/dsh-review-loop` |
-| [dsh-skill-manager](https://github.com/bitterSmilezzz/dsh-skill-manager) | 在 Web 设置页管理（列出/禁用启用/编辑）skills | 1 | `dsh plugin add dsh-skill-manager` |
+| [dsh-skill-manager](https://github.com/bitterSmilezzz/dsh-skill-manager) | 在 Web 设置页管理（列出/禁用启用/编辑）skills（已删除） | 1 | `dsh plugin add dsh-skill-manager` |
 | [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) | 把 Claude Code 记忆/技能/配置桥接进 DSH | 5 | `dsh plugin add dsh-plugin-claude-bridge` |
 | [dsh-plugin-codex-bridge](https://github.com/YYTbit/dsh-plugin-codex-bridge) | 把 Codex skills/config 桥接进 DSH | 2 | `dsh plugin add dsh-plugin-codex-bridge` |
 | [dsh-plugin-opencode-bridge](https://github.com/YYTbit/dsh-plugin-opencode-bridge) | 把 OpenCode skills/config 桥接进 DSH | 3 | `dsh plugin add dsh-plugin-opencode-bridge` |
 | [dsh-plugin-pi-bridge](https://github.com/YYTbit/dsh-plugin-pi-bridge) | 把 pi skills/config 桥接进 DSH | 2 | `dsh plugin add dsh-plugin-pi-bridge` |
 | [Code2Skill](https://github.com/leechen298/Code2Skill) | 从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发 | 2 | `dsh plugin add github:leechen298/Code2Skill#v1.1.3` |
-| [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） | 13 | `dsh plugin add github:dhicoc/dsh-reverse-skill` |
-| [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) | 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill | 84 | `dsh plugin add github:Nagi-ovo/dsh-find-plugins` |
+| [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) | 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） | 12 | `dsh plugin add github:dhicoc/dsh-reverse-skill` |
+| [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) | 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill | 89 | `dsh plugin add github:Nagi-ovo/dsh-find-plugins` |
+| [forkprobe](https://github.com/Jayden-X-L/forkprobe) | 同一任务对比多个 skill 并选出最优 | 66 | `dsh plugin add github:Jayden-X-L/forkprobe` |
 
 </details>
 
@@ -180,7 +181,7 @@
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
 | [dsh-skins](https://github.com/Moeblack/dsh-skins) | Web UI 皮肤合集（含 harbor 夕港黄昏皮肤） | 3 | `dsh plugin add @dsh-external/dsh-web-skins` |
-| [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | DSH Web 鲸鱼娘皮肤系列（深海女仆工坊） | 802 |  |
+| [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | DSH Web 鲸鱼娘皮肤系列（深海女仆工坊） | 834 |  |
 | [dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) | QQ2006 复古皮肤 | 10 |  |
 | [dsh-miku-skin](https://github.com/stushansusu/dsh-miku-skin) | 初音未来主题（蓝紫渐变/毛玻璃/亮暗双主题） | 2 | `dsh plugin add @deepseek-ai/dsh-client-ui-skin-miku` |
 | [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) | 模仿 Excel 的皮肤 | 8 |  |
@@ -190,31 +191,31 @@
 | [dsh-web-background](https://github.com/BruceWu1126/dsh-web-background) | Web UI 背景自定义 | 2 |  |
 | [dsh-plugin-background](https://github.com/gameswu/dsh-plugin-background) | Web UI 壁纸自定义 | 8 |  |
 | [dsh-chat-width](https://github.com/chen-001/dsh-chat-width) | 调整回复宽度（终端宽度感知） | 3 |  |
-| [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) | 换肤系统：21 套内置皮肤 + 一图生成整套配色 | 33 |  |
-| [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 988 | `dsh plugin add dsh-better-sidebar` |
+| [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) | 换肤系统：21 套内置皮肤 + 一图生成整套配色 | 34 |  |
+| [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) | 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab | 1065 | `dsh plugin add dsh-better-sidebar` |
 | [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) | 侧边栏集成文件浏览器、终端和 Git 审查 | 16 | `dsh plugin add @dsh-external/dsh-side-panel` |
 | [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) | 「聚焦会话」精简视图，只关注最终产出结果 | 16 | `dsh plugin add @dingyi222666/dsh-focus-chat` |
-| [ui-status-label](https://github.com/alingalingling/ui-status-label) | 把鲸鱼娘思考时的 "deep diving" 状态文案自定义 | 31 | `dsh plugin add dsh-ui-status-label` |
-| [dsh-navbar](https://github.com/vlln/dsh-navbar) | 对话节点导航条，右缘节点串快速跳转 user 消息 | 22 | `dsh plugin add @dsh-external/dsh-navbar` |
-| [dsh-task-status](https://github.com/vlln/dsh-task-status) | 后台任务状态条：对话页任务进度 + 实时输出 tail | 9 | `dsh plugin add @dsh-external/dsh-task-status` |
+| [ui-status-label](https://github.com/alingalingling/ui-status-label) | 把鲸鱼娘思考时的 "deep diving" 状态文案自定义 | 32 | `dsh plugin add dsh-ui-status-label` |
+| [dsh-navbar](https://github.com/vlln/dsh-navbar) | 对话节点导航条，右缘节点串快速跳转 user 消息 | 23 | `dsh plugin add @dsh-external/dsh-navbar` |
+| [dsh-task-status](https://github.com/vlln/dsh-task-status) | 后台任务状态条：对话页任务进度 + 实时输出 tail | 10 | `dsh plugin add @dsh-external/dsh-task-status` |
 | [dsh-web-archive](https://github.com/renat3u/dsh-web-archive) | 折叠对话中的 Think、Bash 等「无用消息」 | 7 | `dsh plugin add dsh-web-archive` |
 | [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) | 会话里程碑导航条：像 Git 提交图定位每条提问 | 14 | `dsh plugin add dsh-milestone` |
 | [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) | 键盘优先的命令面板（command palette） | 5 | `dsh plugin add @dsh-external/dsh-spotlight` |
 | [dsh-deeplink](https://github.com/qyw233/dsh-deeplink) | `?session=` / `?workspace=` 深链直达指定项目对话 | 1 | `dsh plugin add @dsh-community/dsh-deeplink` |
-| [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) | PiUI 风格 diff 查看器，替换 write/edit 的默认 DiffBlock | 11 | `dsh plugin add @dsh-external/dsh-diff-viewer` |
+| [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) | PiUI 风格 diff 查看器，替换 write/edit 的默认 DiffBlock | 12 | `dsh plugin add @dsh-external/dsh-diff-viewer` |
 | [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) | 跨平台文件拖拽与原始路径插入，无需复制文件 | 7 | `dsh plugin add @bill9109/dsh-drag-and-drop` |
 | [ex-setting](https://github.com/omdsh-dev/ex-setting) | DSH 的设置扩展 | 2 | `dsh plugin add @deepseek-ai/dsh-ex-setting` |
-| [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | 选中文字→批注→回车随消息发送，回复按批注逐条对照 | 48 | `dsh plugin add @omdsh-dev/dsh-annotation` |
+| [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) | 选中文字→批注→回车随消息发送，回复按批注逐条对照 | 50 | `dsh plugin add @omdsh-dev/dsh-annotation` |
 | [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) | 带实时预览的用户/内置 system prompt 分节编辑器 | 2 | `dsh plugin add dsh-prompt-studio` |
 | [dsh-prompt-persona](https://github.com/Xilin3/dsh-prompt-persona) | 从设置页编辑系统提示词（deployment persona），带实时预览 | 4 | `dsh plugin add @xilin3/dsh-prompt-persona` |
-| [dsh-model-selector](https://github.com/bitterSmilezzz/dsh-model-selector) | provider 分组折叠 + 名称搜索的模型选择器增强 | 1 | `dsh plugin add dsh-model-selector` |
+| [dsh-model-selector](https://github.com/bitterSmilezzz/dsh-model-selector) | provider 分组折叠 + 名称搜索的模型选择器增强（已删除） | 1 | `dsh plugin add dsh-model-selector` |
 | [dsh-local-filetree](https://github.com/Mongfayi/dsh-local-filetree) | 右侧详情列显示当前会话工作区文件树（懒加载、只读） | 1 | `dsh plugin add dsh-local-filetree` |
 | [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) | 把滚出屏幕的折叠标签（Think/工具卡）钉在视口顶部 | 3 | `dsh plugin add dsh-sticky-disclosure` |
 | [dsh-token-usage](https://github.com/hashdiana/dsh-token-usage) | 更美观的 Token 用量条：上下文占用/输入输出/缓存分解/首字延迟 | 2 | `dsh plugin add dsh-token-usage` |
-| [dsh-model-config-sync](https://github.com/LiangYin233/dsh-model-config-sync) | 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 | 11 | `dsh plugin add dsh-model-config-sync` |
-| [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2397 | `dsh plugin add dsh-web-ui` |
-| [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览 | 98 | `dsh plugin add @dsh-external/dsh-visualize` |
-| [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景 | 91 | `dsh plugin add @omdsh-dev/dsh-genui` |
+| [dsh-model-config-sync](https://github.com/LiangYin233/dsh-provider-model-configurator) | 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 | 11 | `dsh plugin add dsh-model-config-sync` |
+| [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) | DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 | 2484 | `dsh plugin add dsh-web-ui` |
+| [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) | 对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览 | 100 | `dsh plugin add @dsh-external/dsh-visualize` |
+| [dsh-genui](https://github.com/omdsh-dev/dsh-genui) | 助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景 | 99 | `dsh plugin add @omdsh-dev/dsh-genui` |
 | [web-components](https://github.com/omdsh-dev/web-components) | Web Components 支持 | 2 | `dsh plugin add @deepseek-ai/dsh-client-web-component` |
 | [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | OpenPencil 设计预览与编辑（Agent 操作真实设计画布） | 74 | `dsh plugin add @zseven-w/dsh-openpencil` |
 
@@ -225,31 +226,31 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1120 | `dsh plugin add dsh-cc-tui` |
-| [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 终端 TUI（天枢） | 149 | `dsh plugin add @huiliyi37/dsh-tianshu-tui` |
+| [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 | 1157 | `dsh plugin add dsh-cc-tui` |
+| [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) | DSH 终端 TUI（天枢） | 153 | `dsh plugin add @huiliyi37/dsh-tianshu-tui` |
 | [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) | Pi TUI 前端：流式 markdown、思考折叠、工具卡、斜杠命令 | 1 |  |
 | [deepseek-harness-tui](https://github.com/gxinxing/deepseek-harness-tui) | Ink/React 终端原生 TUI | 7 | `dsh plugin add deepseek-harness-tui` |
 | [dsh-tui](https://github.com/orriduck/dsh-tui) | 轻量、会话感知的终端 UI | 2 | `dsh plugin add dsh-tui` |
-| [dsh-tui](https://github.com/openguardrails/dsh-tui) | Claude Code 风格终端 UI（out-of-tree bundle） | 15 | `dsh plugin add @openguardrails/dsh-tui` |
-| [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验 | 181 | `dsh plugin add @oh-dsh/desktop` |
-| [oh-dsh-desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) | 可扩展 macOS 工作台：原生 PTY、工作区工具、双语插件、隔离预览市场 | 181 |  |
+| [dsh-tui](https://github.com/dsh-tui/dsh-tui) | Claude Code 风格终端 UI（out-of-tree bundle） | 15 | `dsh plugin add @dsh-tui/dsh-tui` |
+| [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) | 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验 | 184 | `dsh plugin add @oh-dsh/desktop` |
 | [deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) | Windows 原生桌面壳：1:1 官方 Web UI + 内置服务器托管 + 托盘驻留 | 10 |  |
-| [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) | 非官方进程内 Windows 桌面应用（托盘 + 原生通知 + IPC） | 1 |  |
-| [dsh-desktop](https://github.com/bruc3van/dsh-desktop) | 社区维护的非官方桌面客户端（复用官方实例或内置运行时） | 25 |  |
+| [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop-windows) | 非官方进程内 Windows 桌面应用（托盘 + 原生通知 + IPC） | 1 |  |
+| [dsh-desktop](https://github.com/bruc3van/dsh-desktop) | 社区维护的非官方桌面客户端（复用官方实例或内置运行时） | 29 |  |
 | [dsh-desktop](https://github.com/zsyu9779/dsh-desktop) | Wails(Go) 桌面壳，Codex 风格原生应用 | 4 |  |
 | [dsh-desktop](https://github.com/mrbbbaixue/dsh-desktop) | .NET 10 WPF + WebView2 桌面启动器 | 2 |  |
-| [dsh-desktop](https://github.com/dataelement/dsh-desktop) | 跨平台桌面应用 | 217 |  |
+| [dsh-desktop](https://github.com/dataelement/dsh-desktop) | 跨平台桌面应用 | 221 |  |
 | [dsh-desktop-electron](https://github.com/Void0312Aurora/dsh-desktop-electron) | 跨平台 Electron 桌面壳（托盘驻留、无内置 Node） | 4 |  |
-| [dsh-mac-desktop](https://github.com/bitterSmilezzz/dsh-mac-desktop) | 在原生 macOS 窗口打开 Web GUI（SwiftUI + WKWebView） | 2 | `dsh plugin add dsh-mac-desktop` |
+| [dsh-mac-desktop](https://github.com/bitterSmilezzz/dsh-mac-desktop) | 在原生 macOS 窗口打开 Web GUI（SwiftUI + WKWebView）（已删除） | 2 | `dsh plugin add dsh-mac-desktop` |
 | [dsh-desktop-window](https://github.com/fengzhiyushui/dsh-desktop-window) | 以独立应用窗口打开 Web UI（自动开窗 + 设置开关） | 1 | `dsh plugin add dsh-desktop-window` |
-| [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4287 |  |
-| [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web | 80 | `dsh plugin add deepseek-harness-desktop` |
-| [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器：开机自启 + 独立小窗口 | 89 |  |
-| [dsh-work](https://github.com/vibeinging/dsh-work) | 本地 AI 工作桌面：Session/文件/数据分析/MCP/Office 一体化 | 115 |  |
+| [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) | 现代化 DeepSeek Harness 桌面端体验 | 4668 |  |
+| [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) | Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web | 81 | `dsh plugin add deepseek-harness-desktop` |
+| [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) | Windows 轻量启动器：开机自启 + 独立小窗口 | 92 |  |
+| [dsh-work](https://github.com/vibeinging/deepseek-harness-desktop-app) | 本地 AI 工作桌面：Session/文件/数据分析/MCP/Office 一体化 | 115 |  |
 | [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) | 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场 | 5 |  |
-| [dsh-mobileweb-adapter](https://github.com/dsh-external/dsh-mobileweb-adapter) | 手机 Web 适配器：让 Web GUI 在手机上可用（⚠️ dsh-external，公开性待核实） |  |  |
-| [dsh-mobile](https://github.com/dsh-external/dsh-mobile) | 移动端客户端（⚠️ dsh-external，公开性待核实） | 12 |  |
-| [dsh-android](https://github.com/dsh-external/dsh-android) | 在 Android 上运行 dsh（⚠️ dsh-external，公开性待核实） |  |  |
+| [dsh-mobileweb-adapter](https://github.com/dsh-external/dsh-mobileweb-adapter) | 手机 Web 适配器：让 Web GUI 在手机上可用（⚠️ dsh-external，已删除） |  |  |
+| [dsh-mobile](https://github.com/lehhair/dsh-mobile) | 移动端客户端（⚠️ dsh-external，公开性待核实） | 12 |  |
+| [dsh-android](https://github.com/dsh-external/dsh-android) | 在 Android 上运行 dsh（⚠️ dsh-external，已删除） |  |  |
+| [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) | Rust/ratatui 编写的 DSH 终端 TUI | 25 | `dsh plugin add github:openma-ai/deepseek-harness-tui` |
 
 </details>
 
@@ -258,18 +259,18 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | AgentTeams 多智能体团队协作 | 302 | `dsh plugin add dsh-agent-teams` |
-| [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | 把 UltraCode 式多 Agent 调度带给 DSH：可生成/保存/治理/观察/恢复的 Workflow 层 | 55 | `dsh plugin add @dsh-external/workflow` |
+| [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) | AgentTeams 多智能体团队协作 | 312 | `dsh plugin add dsh-agent-teams` |
+| [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) | 把 UltraCode 式多 Agent 调度带给 DSH：可生成/保存/治理/观察/恢复的 Workflow 层 | 56 | `dsh plugin add @dsh-external/workflow` |
 | [dsh-meta-orchestrator](https://github.com/jiruidai/dsh-meta-orchestrator) | 模型原生 meta-agent：运行时合成任务专属工作流并协调工具/子代理 | 3 | `dsh plugin add dsh-meta-orchestrator` |
 | [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) | 跨会话消息互发：本机任意会话像 Claude Code 一样互发消息 | 2 | `dsh plugin add @dsh-crosstalk/bundle` |
 | [dsh-agent-messaging](https://github.com/happyren/dsh-agent-messaging) | 跨会话 agent-to-agent 消息投递（按会话名寻址） | 4 | `dsh plugin add dsh-agent-messaging` |
-| [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | 跨实例消息/事件交接（interconnect 服务 + 工具） | 26 | `dsh plugin add dsh-interconnect` |
+| [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) | 跨实例消息/事件交接（interconnect 服务 + 工具） | 27 | `dsh plugin add dsh-interconnect` |
 | [dsh-session-hub](https://github.com/Asaiuta/dsh-session-hub) | 多服务器 DSH 会话聚合与原生操控（hub 网关 + 官方 UI 桥） | 3 | `dsh plugin add dsh-session-hub` |
 | [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) | 可配置子代理 profiles + 实时工具调用/token 显示 + 子会话跳转 | 7 | `dsh plugin add @huanlin/dsh-plugin-yet-another-subagent` |
-| [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) | 双模型 plan/execute 路由（planner 想、executor 做）⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-a2a](https://github.com/dsh-external/dsh-a2a) | Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 | 4 |  |
-| [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) | 子代理树可视化 ⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) | 团队协作（cordis）⚠️ dsh-external，公开性待核实 |  |  |
+| [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) | 双模型 plan/execute 路由（planner 想、executor 做）⚠️ dsh-external，已删除 |  |  |
+| [dsh-a2a](https://github.com/dpskh/dsh-a2a) | Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 | 4 |  |
+| [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) | 子代理树可视化 ⚠️ dsh-external，已删除 |  |  |
+| [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) | 团队协作（cordis）⚠️ dsh-external，已删除 |  |  |
 
 </details>
 
@@ -278,11 +279,11 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） | 76 |  |
+| [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) | 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） | 82 |  |
 | [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) | 模型驱动上下文压缩（ACP）：模型决定何时压缩（移植自 billion-context-pi） | 12 |  |
 | [dsh-memory](https://github.com/Jesse-njx/dsh-memory) | 基于无损会话日志的引用式记忆（事实带 sessionId/eventRange 引用） | 2 | `dsh plugin add @dsh-memory/bundle` |
 | [dsh-memory](https://github.com/ben7am1n/dsh-memory) | 跨会话 SQLite 持久记忆 | 1 | `dsh plugin add dsh-memory` |
-| [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 本地三层记忆（Runtime Memory/可检索文档/受监督 Memory Spaces） | 25 | `dsh plugin add dsh-mnemon` |
+| [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) | Mnemon 本地三层记忆（Runtime Memory/可检索文档/受监督 Memory Spaces） | 26 | `dsh plugin add dsh-mnemon` |
 | [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) | 给所有 AI 工具共用的一层记忆（Context Bundle 注入 + MCP 工具 + 线程捕获） | 5 | `dsh plugin add nowledge-mem-deepseek-harness` |
 | [dsh-plugin-meta-memory](https://github.com/YYTbit/dsh-plugin-meta-memory) | 结构化长期记忆系统 | 2 | `dsh plugin add dsh-plugin-meta-memory` |
 | [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) | 从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5） | 2 | `dsh plugin add @dsh-external/dsh-kb-sieve` |
@@ -291,13 +292,13 @@
 | [context-vista](https://github.com/GooodWei/context-vista) | `/context` 命令 + 环形图实时展示上下文 token 用量与费用 | 4 | `dsh plugin add context-vista` |
 | [distill](https://github.com/LoserFox/distill) | 自动对话蒸馏：后台 subagent 反省 + 技能 create/update | 17 | `dsh plugin add @loserfox/distill` |
 | [dsh-auto-compact](https://github.com/wangxiang0605qvq/dsh-auto-compact) | compact_now 工具，回合结束自动压缩上下文 |  |  |
-| [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) | 上下文管理：节省、注意力优化、压缩档案馆 ⚠️ dsh-external，公开性待核实 |  |  |
-| [dsh-context](https://github.com/bowenliang123/dsh-context) | 上下文洞察面板：展示模型上下文窗口的构成与演化 | 38 | `dsh plugin add dsh-context` |
+| [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) | 上下文管理：节省、注意力优化、压缩档案馆 ⚠️ dsh-external，已删除 |  |  |
+| [dsh-context](https://github.com/bowenliang123/dsh-context) | 上下文洞察面板：展示模型上下文窗口的构成与演化 | 40 | `dsh plugin add dsh-context` |
 | [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) | 对话回退：基于持久 Change Ledger 回滚会话与工作区状态 | 50 | `dsh plugin add @dsh-external/turn-rewind` |
 | [dsh-undo](https://github.com/LingLambda/dsh-undo) | 上下文 undo/redo：回退到上一个已完成步骤并恢复 | 3 | `dsh plugin add dsh-undo` |
 | [dsh-recall](https://github.com/Mongfayi/dsh-recall) | 消息撤回：每条用户消息一个撤销按钮，删除该轮及其后内容（不改代码） | 3 | `dsh plugin add dsh-recall` |
-| [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) | `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行 | 6 | `dsh plugin add @dsh-external/dsh-sidechain` |
-| [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) | 基于分支的消息编辑、reroll、重试与版本时间线 | 20 | `dsh plugin add dsh-message-edit` |
+| [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) | `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行 | 7 | `dsh plugin add @dsh-external/dsh-sidechain` |
+| [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) | 基于分支的消息编辑、reroll、重试与版本时间线 | 21 | `dsh plugin add dsh-message-edit` |
 | [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) | 跨 dsh/Codex/Claude/pi/OpenCode 会话的无索引全文搜索 | 2 |  |
 | [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话 | 29 | `dsh plugin add dsh-chat-import` |
 | [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) | 迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH | 3 | `dsh plugin add dsh-claude-move` |
@@ -309,9 +310,9 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1664 | `dsh plugin add @liustack/modlens` |
-| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts | 401 | `dsh plugin add @dsh-external/dsh-vision-toolkit` |
-| [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) | 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） | 882 |  |
+| [modlens](https://github.com/liustack/modlens) | DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） | 1736 | `dsh plugin add @liustack/modlens` |
+| [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) | 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts | 409 | `dsh plugin add @dsh-external/dsh-vision-toolkit` |
+| [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) | 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） | 887 |  |
 | [dsh-vision](https://github.com/william-jin-cmu/dsh-vision) | view_image 工具桥接任意 OpenAI 兼容 VLM（默认智谱免费档） | 23 |  |
 | [dsh-vision-LMstudio](https://github.com/TiankunDai/dsh-vision-LMstudio) | 通过 LM Studio 调用本地视觉模型 | 1 |  |
 | [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) | DeepSeek 大脑 + 自动识图（图片经 Qwen VLM 转文字后作答） | 8 | `dsh plugin add dsh-vision-proxy` |
@@ -325,26 +326,26 @@
 | [dsh-mobile-control](https://github.com/PangYiMing/dsh-mobile-control) | 操控手机（ADB/iOS） | 2 | `dsh plugin add dsh-mobile-control` |
 | [dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) | 原生鸿蒙设备桥：hdc 截图-看图-装包-验证闭环调试 | 5 | `dsh plugin add dsh-hdc-bridge` |
 | [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) | provider 无关的 AIGC HTTP 桥 + 自由画布 + ffmpeg 后处理 | 6 | `dsh plugin add @huanlin/dsh-plugin-aigc-canvas` |
-| [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） | 108 | `dsh plugin add dsh-vision-router` |
+| [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) | 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） | 111 | `dsh plugin add dsh-vision-router` |
 
 </details>
 
 <details>
-<summary>🔁 工作流 / 自动化 · 20</summary>
+<summary>🔁 工作流 / 自动化 · 21</summary>
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
 | [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) | 自适应深度研究编排器（基于官方 workflow 引擎） | 12 | `dsh plugin add @dsh-external/dsh-deep-research` |
-| [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) | 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） | 4 | `dsh plugin add @deepseek-ai/dsh-deepresearch` |
+| [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) | 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） | 5 | `dsh plugin add @deepseek-ai/dsh-deepresearch` |
 | [dsh-loop](https://github.com/vlln/dsh-loop) | 定时循环：`/loop` 命令 + loop 工具 + 活动状态条 | 3 | `dsh plugin add @dsh-external/dsh-loop` |
 | [dsh-sentinel](https://github.com/fuhefei/dsh-sentinel) | 条件驱动唤醒：file/command/http/process/webhook 持久监视触发 agent | 7 | `dsh plugin add @dsh-external/dsh-sentinel` |
-| [dsh-automation](https://github.com/titanwings/dsh-automation) | 定时任务：Coding 任务按计划在全新 Agent Session 中运行 | 37 | `dsh plugin add @dsh-external/dsh-automation` |
+| [dsh-automation](https://github.com/titanwings/dsh-automation) | 定时任务：Coding 任务按计划在全新 Agent Session 中运行 | 39 | `dsh plugin add @dsh-external/dsh-automation` |
 | [dsh-routines](https://github.com/Jesse-njx/dsh-routines) | cron 定时 Agent：按计划跑 prompt 并把摘要送到你所在处 | 1 | `dsh plugin add @dsh-routines/bundle` |
 | [dsh-plannotator](https://github.com/titanwings/dsh-plannotator) | 计划批注：选中计划原文逐条批注并回送结构化反馈 | 5 | `dsh plugin add @dsh-external/dsh-plannotator` |
 | [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) | 发现问题→修复→复查的对抗式闭环（基于官方 workflow 引擎） | 5 | `dsh plugin add @dsh-external/dsh-inspect` |
-| [dsh-advisor](https://github.com/btspoony/dsh-advisor) | 副模型每轮被动审查并注入见解 | 9 | `dsh plugin add dsh-advisor` |
-| [mstar-harness](https://github.com/btspoony/mstar-harness) | Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 | 45 |  |
-| [dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) | 基于角色的模型重试/备用策略 | 4 | `dsh plugin add dsh-llm-fallbacks` |
+| [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) | 副模型每轮被动审查并注入见解 | 9 | `dsh plugin add dsh-advisor` |
+| [mstar-harness](https://github.com/btspoony/mstar-harness) | Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 | 46 |  |
+| [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) | 基于角色的模型重试/备用策略 | 4 | `dsh plugin add dsh-llm-fallbacks` |
 | [dsh-polyglot](https://github.com/Jesse-njx/dsh-polyglot) | 模型切换器：任意 OpenAI 兼容端点 + 免费/低价 DeepSeek 预设 + 限流自动回退 | 1 | `dsh plugin add @dsh-polyglot/bundle` |
 | [dsh-track](https://github.com/fakechris/dsh-track) | 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储 | 6 | `dsh plugin add @deepseek-ai/dsh-track` |
 | [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay) | 录制 macOS 桌面工作流演示并转成 agent 技能（orr_* 工具） | 7 | `dsh plugin add dsh-record-replay` |
@@ -354,11 +355,12 @@
 | [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) | 手动审批模式（Manual/Ask Mode） | 1 | `dsh plugin add dsh-tool-approval` |
 | [dsh-tiered-approval](https://github.com/Elaina-real/dsh-tiered-approval) | 分层自动审查：静态规则 + LLM 审查 + 人工兜底 | 2 | `dsh plugin add dsh-tiered-approval` |
 | [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) | 事件流审计面板：观察事件类型/分发模式/计数，帮插件作者理解内部 | 1 | `dsh plugin add @dsh-external/dsh-event-auditor` |
+| [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) | 自动续传：网络中断后自动发「继续」恢复请求 | 15 | `dsh plugin add github:HsiangNianian/dsh-auto-continue` |
 
 </details>
 
 <details>
-<summary>📡 通知 / 渠道 / 远程 · 18</summary>
+<summary>📡 通知 / 渠道 / 远程 · 17</summary>
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
@@ -366,20 +368,19 @@
 | [dsh-telegram](https://github.com/ben7am1n/dsh-telegram) | Telegram 运行时适配器（per-chat 会话、allowlist 认证） | 1 | `dsh plugin add dsh-telegram` |
 | [DSH-Telegram-Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) | 通过 Telegram 远程对话并接收通知 | 5 | `dsh plugin add dsh-telegram-relay` |
 | [dsh-chatnode-wechat](https://github.com/Jesse-njx/dsh-chatnode-wechat) | 通过 iLink 网关在微信里与 DSH agent 聊天/监控/审批 | 2 | `dsh plugin add @dsh-cowork/chatnode-wechat` |
-| [dsh-lark](https://github.com/Roy-oss1/dsh-lark) | 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片 | 2 | `dsh plugin add @dsh-contrib/dsh-lark-channel` |
+| [dsh-lark](https://github.com/Roy-oss1/dsh-lark) | 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片（已删除） | 2 | `dsh plugin add @dsh-contrib/dsh-lark-channel` |
 | [dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) | 双向飞书控制器 | 7 | `dsh plugin add dsh-lark-bridge` |
 | [dsh-onlyne](https://github.com/dbydd/dsh-onlyne) | IM 网关：从 dsh 会话收发 QQ/微信/飞书/Telegram 消息 | 2 |  |
-| [dsh-notification](https://github.com/omdsh-dev/dsh-notification) | 回合完成桌面通知，按结果分控 + 关键词过滤 | 45 | `dsh plugin add dsh-notification` |
+| [dsh-notification](https://github.com/omdsh-dev/dsh-notification) | 回合完成桌面通知，按结果分控 + 关键词过滤 | 47 | `dsh plugin add dsh-notification` |
 | [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) | Windows 通知（零依赖） | 3 |  |
 | [dsh-win-notify](https://github.com/MuziIsabel/dsh-win-notify) | Windows toast 通知（任务完成带声音） | 4 | `dsh plugin add dsh-win-notify` |
 | [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) | 桌面通知提醒 | 12 | `dsh plugin add @bill9109/dsh-web-ui-notify` |
-| [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) | 会话完成等四种状态通知，支持浏览器提示 | 6 | `dsh plugin add @dingyi222666/dsh-session-notification` |
+| [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) | 会话完成等四种状态通知，支持浏览器提示 | 7 | `dsh plugin add @dingyi222666/dsh-session-notification` |
 | [dsh-ssh](https://github.com/UynajGI/dsh-ssh) | SSH 远程执行（ProxyJump 链、SFTP 文件系统、PTY） | 4 |  |
 | [dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) | 通用 webhook 接收器：POST /hook/:channel 唤醒 per-channel agent | 1 | `dsh plugin add dsh-webhook-bridge` |
-| [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) | 从 Web GUI 一键在 VS Code 中打开工作区目录 | 41 | `dsh plugin add dsh-open-in-vscode` |
-| [dsh-share](https://github.com/hellodigua/dsh-share) | 一键分享你的对话 | 18 | `dsh plugin add @dsh-external/dsh-share` |
+| [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) | 从 Web GUI 一键在 VS Code 中打开工作区目录 | 42 | `dsh plugin add dsh-open-in-vscode` |
+| [dsh-share](https://github.com/hellodigua/dsh-share) | 一键分享你的对话 | 19 | `dsh plugin add @dsh-external/dsh-share` |
 | [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) | 分享任意段落的对话 | 1 | `dsh plugin add @bill9109/dsh-conversation-share` |
-| [dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) | BitFun 与 DSH 的 ACP 交互对接 | 9 | `dsh plugin add dsh-acp-for-bitfun` |
 
 </details>
 
@@ -388,7 +389,7 @@
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [dsh-browser](https://github.com/Lum1104/dsh-browser) | Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） | 133 |  |
+| [dsh-browser](https://github.com/Lum1104/dsh-browser) | Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） | 140 |  |
 | [dsh-browser-control](https://github.com/PangYiMing/dsh-browser-control) | CDP/Playwright 操控浏览器 | 1 | `dsh plugin add dsh-browser-control` |
 | [ego-browser](https://github.com/Fisfzy/ego-browser) | 把 ego-lite（给 AI Agent 的 Chromium）接入 DSH，13 个结构化 ego_* 工具 | 13 |  |
 | [dsh-better-browser](https://github.com/titanwings/dsh-better-browser) | 通过 Kimi WebBridge 让 Agent 操作用户已登录浏览器（13 个工具） | 7 | `dsh plugin add @dsh-external/dsh-better-browser` |
@@ -397,29 +398,28 @@
 | [DSH-Chrome-devtools](https://github.com/yuzi-ska/DSH-Chrome-devtools) | 基于 Chrome DevTools MCP 的真实 Chrome 控制 | 1 | `dsh plugin add dsh-chrome-devtools` |
 | [dsh-playwright-cli](https://github.com/mitao-su/dsh-playwright-cli) | 包装 Playwright CLI：装浏览器、跑测试、从 agent 循环打开 HTML 报告 | 2 | `dsh plugin add dsh-playwright-cli` |
 | [deepseek-pp](https://github.com/zhu1090093659/deepseek-pp) | 浏览器扩展 AI Agent 工作区，内置 MCP 与记忆 | 1558 |  |
-| [dsh-webfetch](https://github.com/withlovehub/dsh-webfetch) | 零依赖 webfetch MCP server（robots 合规、SSRF 防护） | 2 |  |
 | [dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) | Firecrawl 搜索提供方接入内置 web_search | 2 | `dsh plugin add @yangzhe1003/dsh-web-search-firecrawl` |
 | [dsh-web-search-tavily](https://github.com/crayonlu/dsh-web-search-tavily) | Tavily 搜索提供方（免 DeepSeek key） | 3 |  |
 | [dsh-tavily-search](https://github.com/zhouzhencheng07/dsh-tavily-search) | 免 key Tavily 搜索工具 | 2 | `dsh plugin add dsh-tavily-search` |
 | [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) | 增强持久搜索（多引擎 + SQLite/LRU 缓存 + Playwright 渲染） | 7 | `dsh plugin add dsh-web-search-pro` |
 | [dsh-all-search](https://github.com/RealAlexandreAI/dsh-all-search) | AnySearch 网页搜索提供方（ctx.web） | 1 | `dsh plugin add dsh-all-search` |
-| [modsearch](https://github.com/liustack/modsearch) | CLI 搜索工具：把搜索查询转结构化 web 证据 JSON | 103 | `dsh plugin add @liustack/modsearch` |
+| [modsearch](https://github.com/liustack/modsearch) | CLI 搜索工具：把搜索查询转结构化 web 证据 JSON | 104 | `dsh plugin add @liustack/modsearch` |
+| [argo](https://github.com/taxueseek/argo) | 为 agent 打造的多语言搜索工具（中文/英文/学术/代码/购物/金融/新闻/百科） | 77 | `dsh plugin add github:taxueseek/argo` |
 
 </details>
 
 <details>
-<summary>🏗️ 基础设施 / 插件管理 / 开发工具 · 32</summary>
+<summary>🏗️ 基础设施 / 插件管理 / 开发工具 · 33</summary>
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [plugin-registry](https://github.com/dsh-external/plugin-registry) | 第三方本地插件系统：`dsh.plugin.json` 协议 + install/enable/disable + Web 面板（公开） | 40 |  |
 | [plugin-registry](https://github.com/vlln/plugin-registry) | 插件管理控制台：浏览器面板管理官方 repository 插件 + 开发引导 | 40 |  |
 | [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) | 离线容忍的注册表：从 awesome 列表/GitHub topics/npm 发现并去重 DSH 插件 | 1 |  |
 | [dsh-hub](https://github.com/omdsh-dev/dsh-hub) | OMDSH 社区扩展 hub（基于官方 contracts） | 4 | `dsh plugin add @omdsh/dsh-hub` |
 | [DSH-plugin-switch](https://github.com/Nexus-Aethra/DSH-plugin-switch) | 插件市场：浏览/搜索/安装 GitHub 项目，自动识别 plugin/skill | 2 | `dsh plugin add dsh-plugin-switch` |
 | [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) | 把 DSH 快速接入 GitHub 插件生态的市场插件 | 6 | `dsh plugin add dsh-plugin-installer` |
-| [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） | 39 | `dsh plugin add @dsh-external/dsh-super-injector` |
-| [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop | 46 |  |
+| [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） | 48 | `dsh plugin add @dsh-external/dsh-super-injector` |
+| [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) | 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop | 47 |  |
 | [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) | 插件健康检查：扫描清单协议/patch 格式/构建陷阱/hub 状态 | 17 | `dsh plugin add @deepseek-ai/dsh-plugin-check` |
 | [dsh-plugin-doctor](https://github.com/lin-cheng-lab/dsh-plugin-doctor) | 插件体检：安装前检查 peer 版本兼容性 | 1 | `dsh plugin add dsh-plugin-doctor` |
 | [dsh-doctor](https://github.com/asdf17128/dsh-doctor) | profile 健康检查：找 patch 静默破坏的配置/死 patch/工具名冲突 | 1 |  |
@@ -444,11 +444,13 @@
 | [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) | Multica 的 DSH runtime 桥接（stdio JSONL 协议） | 34 | `dsh plugin add @multica-ai/dsh-runtime` |
 | [session-teleport](https://github.com/omdsh-dev/session-teleport) | PostgreSQL 单写者会话交接服务 | 2 | `dsh plugin add @mattheliu/session-teleport` |
 | [session-persistence-rdb](https://github.com/morlay/session-persistence-rdb) | session 关系型数据库持久化 | 4 | `dsh plugin add @morlay/session-persistence-rdb` |
+| [dsh-market](https://github.com/dsh-market/dsh-market) | DSH 可视化插件市场：浏览/搜索/一键安装 | 221 | `dsh plugin add github:dsh-market/dsh-market` |
+| [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) | dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin 目录/安装/卸载 | 42 | `dsh plugin add github:Sanqi-normal/dsh-webui-market-plugin` |
 
 </details>
 
 <details>
-<summary>🎮 娱乐 / 其他 · 28</summary>
+<summary>🎮 娱乐 / 其他 · 31</summary>
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
@@ -457,13 +459,13 @@
 | [dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) | 自走棋：人机对战或双 AI 对弈 | 3 | `dsh plugin add @deepseek-ai/dsh-auto-chess` |
 | [dsh-plugin-d399](https://github.com/HuanLinOTO/dsh-plugin-d399) | 模型生成时弹出小游戏菜单（wordle/消消乐，可扩展） | 5 | `dsh plugin add @huanlin/dsh-plugin-d399` |
 | [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) | 全手绘像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心） | 30 |  |
-| [whale-girl](https://github.com/vlln/whale-girl) | 桌面宠物鲸鱼娘（QQ 宠物形态，可拖拽/投喂/玩耍） | 159 | `dsh plugin add whale-girl` |
+| [whale-girl](https://github.com/vlln/whale-girl) | 桌面宠物鲸鱼娘（QQ 宠物形态，可拖拽/投喂/玩耍） | 160 | `dsh plugin add whale-girl` |
 | [dsh-pixel-whale](https://github.com/yoke233/dsh-pixel-whale) | 活泼像素鲸鱼运行状态伴侣 | 1 | `dsh plugin add dsh-pixel-whale` |
 | [dsh-blue-whale-maid](https://github.com/yuxino/dsh-blue-whale-maid) | 蓝鲸女仆桌面像素宠物 | 3 | `dsh plugin add dsh-blue-whale-maid` |
-| [deepseek-pet](https://github.com/keleus/deepseek-pet) | 在 DSH 上养一只大蓝鲸 | 15 | `dsh plugin add deepseek-pet` |
-| [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) | 用户与 agent 双向表情贴纸互动 | 15 | `dsh plugin add @dsh-external/dsh-stickers` |
+| [deepseek-pet](https://github.com/keleus/deepseek-pet) | 在 DSH 上养一只大蓝鲸 | 18 | `dsh plugin add deepseek-pet` |
+| [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) | 用户与 agent 双向表情贴纸互动 | 16 | `dsh plugin add @dsh-external/dsh-stickers` |
 | [dsh-emoji](https://github.com/hellodigua/dsh-emoji) | 为 AI 回复自动添加表情 | 17 | `dsh plugin add @dsh-external/dsh-emoji` |
-| [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 2005 中文站点风格整活广告（侧栏/信息流/弹窗，素材全虚构） | 388 | `dsh plugin add @dsh-external/dsh-ads` |
+| [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) | 2005 中文站点风格整活广告（侧栏/信息流/弹窗，素材全虚构） | 396 | `dsh plugin add @dsh-external/dsh-ads` |
 | [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) | 股票行情数据插件（整活向） | 11 | `dsh plugin add dsh-stock-market` |
 | [dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) | 侧栏短视频：原生播放器、系列导航、历史回放 | 2 | `dsh plugin add dsh-douyin` |
 | [deepseek-manners](https://github.com/Moeblack/deepseek-manners) | 每次消息后注入感谢语，做个有礼貌的人 | 10 | `dsh plugin add deepseek-manners` |
@@ -471,39 +473,41 @@
 | [dsh-fun-typewriter](https://github.com/omdsh-dev/dsh-fun-typewriter) | WebAudio 打字机氛围音效（零音频资源） | 3 | `dsh plugin add @deepseek-ai/dsh-fun-typewriter` |
 | [dsh-daily-fortune](https://github.com/omdsh-dev/dsh-daily-fortune) | 每日运势：观音签、塔罗、每日一句 | 3 | `dsh plugin add @deepseek-ai/dsh-daily-fortune` |
 | [dsh-plugin-spur](https://github.com/HuanLinOTO/dsh-plugin-spur) | 挂在聊天流里的辫子，抓住甩一甩给 agent 发「去干活」 | 3 | `dsh plugin add @huanlin/dsh-plugin-spur` |
-| [dsh-toy](https://github.com/c3ll256/dsh-toy) | 连接小型玩具到 DSH（Toy Control Protocol） | 38 | `dsh plugin add dsh-toy` |
+| [dsh-toy](https://github.com/c3ll256/dsh-toy) | 连接小型玩具到 DSH（Toy Control Protocol） | 43 | `dsh plugin add dsh-toy` |
 | [dsh-learn-everything](https://github.com/cendaifeng/dsh-learn-everything) | 费曼学习模式：教→讲回→判→再解释，渲染为富 HTML 课程卡 | 4 | `dsh plugin add dsh-learn-everything` |
 | [dsh-openmaic](https://github.com/THU-MAIC/dsh-openmaic) | OpenMAIC 教学：课堂、幻灯片、交互组件、苏格拉底式教学 | 8 | `dsh plugin add @openmaic/dsh-openmaic` |
 | [dsh-scholar](https://github.com/lzszq/dsh-scholar) | 学术助手插件 | 15 | `dsh plugin add @dsh-scholar/research-plugin` |
 | [dsh-101](https://github.com/bill9109/dsh-101) | DSH 文档阅读模式 | 3 | `dsh plugin add @dsh-external/dsh-101` |
 | [dsh-reasoning-translator](https://github.com/pinkllo/dsh-reasoning-translator) | 让模型的思维链用你的语言输出 | 2 | `dsh plugin add dsh-reasoning-translator` |
-| [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) | OpenPencil 设计预览与编辑（Agent 操作真实设计画布） | 74 | `dsh plugin add @zseven-w/dsh-openpencil` |
 | [dsh-director-toolkit](https://github.com/lhmd/dsh-director-toolkit) | 3D 艺术家/技术美术方向包：Blender/Three.js/Houdini/C4D 方向指引 | 7 | `dsh plugin add @lhmd/dsh-director-toolkit` |
 | [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) | Xcode AI 集成：26 个 Xcode MCP 工具 + Apple 平台技能 | 1 | `dsh plugin add dsh-apple-mode` |
+| [notes](https://github.com/zhaoolee/notes) | 开源版锤子便签：导出 DSH 会话为便签图片，支持 skill 调用 ⚠️ 无 license 文件 | 142 |  |
+| [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) | DSH 会话费用统计（本会话/当日/历史 + 官方价格同步） | 31 | `dsh plugin add github:Han-1413141/dsh-cost-meter` |
+| [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) | persona 驱动的 UX 走查：扫描 React/TS 源码找 UX 问题 | 18 | `dsh plugin add github:DietCokewithSugar/dsh-user-experience` |
+| [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) | DeepSeek 账户余额与会话成本显示 | 13 | `dsh plugin add github:Ghost011118/dsh-balance-meter` |
 
 </details>
 
 <details>
-<summary>🏛️ 官方核心与元项目 · 17</summary>
+<summary>🏛️ 官方核心与元项目 · 16</summary>
 
 | 插件 | 描述 | ⭐ | 安装命令 |
 |---|---|---|---|
-| [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 107568 |  |
-| [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5850 |  |
-| [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2326 |  |
-| [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) | 「30 秒找到适合你的插件」，带场景说明 + 505 全量快照 | 132 |  |
-| [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) | DSH 生态精选：插件/工具/基础设施 | 454 |  |
-| [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 928 |  |
-| [Alex-Yanggg/awesome-DSH-plugin](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | 覆盖生产力/扩展/调试/自定义开发的分类 catalog | 61 |  |
-| [dsh-external/hub](https://github.com/dsh-external/hub) | 社区组织级索引/目录元仓库（⚠️ 私有，白名单可见） |  |  |
-| [dsh-external/plugin-registry](https://github.com/dsh-external/plugin-registry) | 第三方插件系统：`dsh.plugin.json` 协议（公开） | 40 |  |
-| [dsh-external/marisa](https://github.com/dsh-external/marisa) | 「寄生式」外部插件管理器 `dshx`（⚠️ 私有，白名单可见） |  |  |
-| [dsh-external/toybox](https://github.com/dsh-external/toybox) | 插件玩具箱：静态 `.dsh-plugin` 格式的技能/MCP 插件收藏（公开） |  |  |
+| [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) | 官方核心仓库：「一切皆插件」，Cordis 驱动 | 109475 |  |
+| [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) | 官方 Agent 精选列表 | 5853 |  |
+| [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) | 社区精选列表（105 插件 + 站点 + 徽章） | 2519 |  |
+| [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) | 「30 秒找到适合你的插件」，带场景说明 + 505 全量快照 | 139 |  |
+| [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) | DSH 生态精选：插件/工具/基础设施 | 465 |  |
+| [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) | 目录 + **每日兼容性雷达**（四维检查 + 运行实测） | 942 |  |
+| [Alex-Yanggg/awesome-DSH-plugin](https://github.com/Alex-Yanggg/awesome-DSH-plugin) | 覆盖生产力/扩展/调试/自定义开发的分类 catalog | 62 |  |
+| [dsh-external/hub](https://github.com/dsh-external/hub) | 社区组织级索引/目录元仓库（⚠️ 私有，白名单可见） （已删除） |  |  |
+| [dsh-external/marisa](https://github.com/dsh-external/marisa) | 「寄生式」外部插件管理器 `dshx`（⚠️ 私有，白名单可见） （已删除） |  |  |
+| [dsh-external/toybox](https://github.com/dsh-external/toybox) | 插件玩具箱：静态 `.dsh-plugin` 格式的技能/MCP 插件收藏（公开） （已删除） |  |  |
 | [HenryZ838978/deepseek-harness](https://github.com/HenryZ838978/deepseek-harness) | 第三方 Harness：Python 库 + dsh CLI + MCP server + SKILL.md | 40 |  |
 | [vvlife/whalehub-dsh](https://github.com/vvlife/whalehub-dsh) | 第三方插件商店/中心 | 4 |  |
-| [dsh-plugin-guide](https://github.com/dsh-external/dsh-plugin-guide) | DSH 插件开发指南：从零到精通 ⚠️ 公开性待核实 |  |  |
-| [dsh-cordis-rocks](https://github.com/dsh-external/dsh-cordis-rocks) | 16 章可逆 Cordis 配套教程 ⚠️ 公开性待核实 |  |  |
-| [dsh-cordis-examples](https://github.com/dsh-external/dsh-cordis-examples) | 最小原生 DSH/Cordis 扩展示例 ⚠️ 公开性待核实 |  |  |
+| [dsh-plugin-guide](https://github.com/dsh-external/dsh-plugin-guide) | DSH 插件开发指南：从零到精通 ⚠️ 已删除 |  |  |
+| [dsh-cordis-rocks](https://github.com/dsh-external/dsh-cordis-rocks) | 16 章可逆 Cordis 配套教程 ⚠️ 已删除 |  |  |
+| [dsh-cordis-examples](https://github.com/dsh-external/dsh-cordis-examples) | 最小原生 DSH/Cordis 扩展示例 ⚠️ 已删除 |  |  |
 | [plugin-template](https://github.com/omdsh-dev/plugin-template) | 插件模板仓库（基于 turtle-ui） | 5 | `dsh plugin add @your-scope/dsh-plugin-template` |
 
 </details>

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-08-15T12:13:14.260Z",
+  "updatedAt": "2026-08-15T13:56:51.234Z",
   "plugins": [
     {
       "fullName": "AcidGr/dsh-web-mobile-fix",
@@ -89,15 +89,16 @@
       "fullName": "bowenliang123/dsh-context",
       "url": "https://github.com/bowenliang123/dsh-context",
       "description": "Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.",
-      "stars": 38,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 40,
+      "pushedAt": "2026-08-15T00:42:10Z",
+      "license": "Apache-2.0",
       "isPlugin": true,
       "npmName": "dsh-context",
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "wjy9902/dsh-web-default-session",
@@ -131,15 +132,16 @@
       "fullName": "huiliyi37/dsh-tianshu-tui",
       "url": "https://github.com/huiliyi37/dsh-tianshu-tui",
       "description": "A terminal UI (TUI) for DeepSeek Harness.",
-      "stars": 149,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 153,
+      "pushedAt": "2026-08-15T13:25:11Z",
+      "license": "Apache-2.0",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "openma-ai/deepseek-harness-tui",
@@ -173,29 +175,31 @@
       "fullName": "omdsh-dev/dsh-at-file",
       "url": "https://github.com/omdsh-dev/dsh-at-file",
       "description": "Codex-style `@file` mentions: search workspace files in the composer and attach their contents to prompts.",
-      "stars": 187,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 198,
+      "pushedAt": "2026-08-14T16:15:06Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "alingalingling/ui-status-label",
       "url": "https://github.com/alingalingling/ui-status-label",
       "description": "Customize the \"deep diving\" thinking status label to anything you like.",
-      "stars": 31,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 32,
+      "pushedAt": "2026-08-15T08:57:01Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "LeemanCheung/dsh-whale-animation",
@@ -230,98 +234,105 @@
       "url": "https://github.com/ZSeven-W/dsh-openpencil",
       "description": "OpenPencil design preview and editing plugin.",
       "stars": 74,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T14:36:17Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "@zseven-w/dsh-openpencil",
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Nagi-ovo/dsh-visualize",
       "url": "https://github.com/Nagi-ovo/dsh-visualize",
       "description": "In-conversation generative UI: the model renders interactive HTML cards into the chat stream, with streaming preview and sandboxed rendering.",
-      "stars": 98,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 100,
+      "pushedAt": "2026-08-14T23:22:56Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "ccq1/dsh-side-panel",
       "url": "https://github.com/ccq1/dsh-side-panel",
       "description": "Side panel with file browser, terminal, and Git review for quick file previews.",
       "stars": 16,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T17:45:41Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": true
     },
     {
       "fullName": "dingyi222666/dsh-focus-chat",
       "url": "https://github.com/dingyi222666/dsh-focus-chat",
       "description": "A \"focus chat\" minimal view that shows only final outputs.",
       "stars": 16,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-14T10:01:53Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-genui",
       "url": "https://github.com/omdsh-dev/dsh-genui",
       "description": "Interactive UI components rendered inline in replies: layout, charts, forms, quizzes, mermaid, 3D scenes, and an action event loop back to the model.",
-      "stars": 91,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 99,
+      "pushedAt": "2026-08-14T21:31:14Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-annotation",
       "url": "https://github.com/omdsh-dev/dsh-annotation",
       "description": "Select text → annotate → send with your message; replies map back to each annotation.",
-      "stars": 48,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 50,
+      "pushedAt": "2026-08-15T10:43:01Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "vlln/dsh-navbar",
       "url": "https://github.com/vlln/dsh-navbar",
       "description": "Conversation node navigation bar for quick jumps between user messages.",
-      "stars": 22,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 23,
+      "pushedAt": "2026-08-13T14:22:13Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "asukasec/dsh-message-preview",
@@ -355,15 +366,16 @@
       "fullName": "vlln/dsh-task-status",
       "url": "https://github.com/vlln/dsh-task-status",
       "description": "Background task status bar: progress plus live output tail on the chat page.",
-      "stars": 9,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 10,
+      "pushedAt": "2026-08-13T14:22:16Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Nanki-nn/dsh-answer-pet",
@@ -384,28 +396,30 @@
       "url": "https://github.com/renat3u/dsh-web-archive",
       "description": "Collapse noisy messages (Think, Bash, etc.) in conversations.",
       "stars": 7,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-13T04:47:29Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "0xsline/dsh-spotlight",
       "url": "https://github.com/0xsline/dsh-spotlight",
       "description": "Keyboard-first command palette for the DSH Web UI.",
       "stars": 5,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T10:40:39Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "GooodWei/arcana",
@@ -426,42 +440,45 @@
       "url": "https://github.com/GooodWei/context-vista",
       "description": "A right-side floating panel and /context command for DeepSeek Harness — a live donut chart of context token usage, allocation, and estimated cost.",
       "stars": 4,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T02:36:50Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "context-vista",
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "bill9109/dsh-101",
       "url": "https://github.com/bill9109/dsh-101",
       "description": "Document reading mode for DSH.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T11:55:08Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "bill9109/dsh-drag-and-drop",
       "url": "https://github.com/bill9109/dsh-drag-and-drop",
       "description": "Cross-platform file drag-and-drop with raw path insertion, no file copying.",
       "stars": 7,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T13:42:41Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "taxueseek/dsh-files",
@@ -496,56 +513,60 @@
       "url": "https://github.com/qyw233/dsh-deeplink",
       "description": "Deep links: open a specific session or workspace via `?session=` / `?workspace=`.",
       "stars": 1,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T14:00:30Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "lehhair/dsh-diff-viewer",
       "url": "https://github.com/lehhair/dsh-diff-viewer",
       "description": "PiUI-style diff viewer replacing the stock DiffBlock for write/edit tool calls.",
-      "stars": 11,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "stars": 12,
+      "pushedAt": "2026-08-15T04:28:16Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/ex-setting",
       "url": "https://github.com/omdsh-dev/ex-setting",
       "description": "Settings extensions for DSH.",
       "stars": 2,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T14:48:11Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/web-components",
       "url": "https://github.com/omdsh-dev/web-components",
       "description": "Web Components support.",
       "stars": 2,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-09T10:59:54Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "vibeinging/dsh-turn-navigator",
@@ -566,14 +587,15 @@
       "url": "https://github.com/SnowCrescenter-tech/dsh-milestone",
       "description": "Right-side dot-timeline rail: jump between user messages.",
       "stars": 14,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:57:35Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Ghost011118/dsh-balance-meter",
@@ -691,29 +713,31 @@
       "fullName": "ccch1mneyyy/dsh-TUI",
       "url": "https://github.com/ccch1mneyyy/dsh-TUI",
       "description": "Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion.",
-      "stars": 1120,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 1157,
+      "pushedAt": "2026-08-15T13:56:38Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/DSH-better-sidebar",
       "url": "https://github.com/omdsh-dev/DSH-better-sidebar",
       "description": "Full sidebar workbench with file rendering and editing, terminal, Git, and subagents; third-party plugins can register new tabs.",
-      "stars": 988,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 1065,
+      "pushedAt": "2026-08-15T13:48:01Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "tsonglew/dsh-workspace-search",
@@ -748,14 +772,15 @@
       "url": "https://github.com/Han-1413141/dsh-sticky-disclosure",
       "description": "One-click collapse of every expanded section (Think rows, tool cards) with a live-count pill and a customizable hotkey.",
       "stars": 3,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T08:18:01Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "ui",
         "title": "UI 增强 / UI Enhancements"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Meredith2328/dsh-sticky-note",
@@ -1195,15 +1220,16 @@
       "fullName": "Small-tailqwq/dsh-deep-whale",
       "url": "https://github.com/Small-tailqwq/dsh-deep-whale",
       "description": "Whale-girl skin series for the DSH Web UI (maid-atelier).",
-      "stars": 802,
-      "pushedAt": "2026-08-14T00:00:00Z",
+      "stars": 834,
+      "pushedAt": "2026-08-15T09:02:38Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "theme",
         "title": "主题与外观 / Themes & Appearance"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "wsxwj123/dsh-plugins#theme-gallery",
@@ -1294,28 +1320,30 @@
       "url": "https://github.com/Anionex/dsh-turn-rewind",
       "description": "Rewind conversation and workspace state, powered by a persistent Change Ledger.",
       "stars": 50,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T14:59:21Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Jesse-njx/dsh-crosstalk",
       "url": "https://github.com/Jesse-njx/dsh-crosstalk",
       "description": "Cross-session messaging for DSH: any session on the machine can list and message any other, Claude Code-style, via a local heartbeat registry and inbox.",
       "stars": 2,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T17:05:13Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "dongsheng123132/task-passport",
@@ -1349,57 +1377,61 @@
       "fullName": "hellodigua/dsh-share",
       "url": "https://github.com/hellodigua/dsh-share",
       "description": "Share your conversations with one click.",
-      "stars": 18,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 19,
+      "pushedAt": "2026-08-15T07:59:20Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Moeblack/dsh-message-edit",
       "url": "https://github.com/Moeblack/dsh-message-edit",
       "description": "Branch-based message editing, reroll, retry, and a version timeline.",
-      "stars": 20,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "stars": 21,
+      "pushedAt": "2026-08-14T06:12:15Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Buyi-wsgzg/dsh-sidechain",
       "url": "https://github.com/Buyi-wsgzg/dsh-sidechain",
       "description": "`/side` persistent side sessions and `/btw` one-shot side questions, run in a temporary fork without touching main history.",
-      "stars": 6,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 7,
+      "pushedAt": "2026-08-14T03:40:19Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "bill9109/dsh-conversation-share",
       "url": "https://github.com/bill9109/dsh-conversation-share",
       "description": "Share any excerpt of a conversation.",
       "stars": 1,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T07:56:01Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "yuezengwu/dsh-explain",
@@ -1420,14 +1452,15 @@
       "url": "https://github.com/Moeblack/dsh-prompt-studio",
       "description": "Edit user and built-in system-prompt sections with live preview.",
       "stars": 2,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T14:00:19Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "czm15053/dsh-peer-link",
@@ -1462,14 +1495,15 @@
       "url": "https://github.com/Nwflower/dsh-chat-import",
       "description": "Import full-fidelity chat histories from 13 coding agents (Claude Code, Codex, ChatGPT, Cursor, Gemini, opencode, and more) as resumable DeepSeek Harness sessions, with reverse export back to Claude Code.",
       "stars": 29,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T09:01:33Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Nwflower/dsh-file-claim",
@@ -1489,15 +1523,16 @@
       "fullName": "Chinesezjc/dsh-interconnect",
       "url": "https://github.com/Chinesezjc/dsh-interconnect",
       "description": "Cross-instance message and event handoff between DSH instances via an interconnect server.",
-      "stars": 26,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 27,
+      "pushedAt": "2026-08-14T06:32:47Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "session",
         "title": "会话与消息 / Sessions & Messages"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "3403473060/dsh-inline-images",
@@ -1630,28 +1665,30 @@
       "url": "https://github.com/LoserFox/distill",
       "description": "Automatic conversation distillation: background subagent reflection + skill create/update.",
       "stars": 17,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-13T13:11:31Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "memory",
         "title": "记忆 / Memory"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-mnemon",
       "url": "https://github.com/omdsh-dev/dsh-mnemon",
       "description": "Deep Mnemon integration: local three-tier memory (Runtime Memory, retrievable Documents, supervised Memory Spaces).",
-      "stars": 25,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 26,
+      "pushedAt": "2026-08-14T23:49:21Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "dsh-mnemon",
       "category": {
         "id": "memory",
         "title": "记忆 / Memory"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "modusensus/dsh-mneme",
@@ -1672,28 +1709,30 @@
       "url": "https://github.com/nowledge-co/nowledge-mem-deepseek-harness",
       "description": "One memory layer for every AI tool and agent: Context Bundle injection, prompt-time recall, MCP tools, and turn-end DSH thread capture.",
       "stars": 5,
-      "pushedAt": "2026-08-14T00:00:00Z",
+      "pushedAt": "2026-08-13T13:54:56Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "memory",
         "title": "记忆 / Memory"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Jesse-njx/dsh-memory",
       "url": "https://github.com/Jesse-njx/dsh-memory",
       "description": "Cited memory over DSH's lossless session log: distilled facts carry `(sessionId, eventRange)` citations that expand back to the exact original log excerpt.",
       "stars": 2,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T16:39:45Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "memory",
         "title": "记忆 / Memory"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "flymysql/dsh-memory",
@@ -1951,29 +1990,31 @@
       "fullName": "ysr666/dsh-vision-router",
       "url": "https://github.com/ysr666/dsh-vision-router",
       "description": "Free vision for text-only agents: built-in keyless vision chain plus pixel tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots); paste an image to use it.",
-      "stars": 108,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 111,
+      "pushedAt": "2026-08-15T13:43:33Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Flyvhidbwo/dsh-vision-proxy",
       "url": "https://github.com/Flyvhidbwo/dsh-vision-proxy",
       "description": "DeepSeek brain + automatic image transcription: attach images in the GUI and each one is transcribed to text via any OpenAI-compatible VLM before reaching the text-only DeepSeek — a keyed fast path (default qwen3.7-flash; DashScope/Zhipu/OpenRouter or any OpenAI-compatible endpoint) with your own key, or local Ollama auto-detected with zero config.",
       "stars": 8,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T14:52:31Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "dsh-vision-proxy",
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "ximengxiaolan/dsh-vision-bridge",
@@ -2063,15 +2104,16 @@
       "fullName": "Anionex/dsh-vision-toolkit",
       "url": "https://github.com/Anionex/dsh-vision-toolkit",
       "description": "Vision tasks for text-only models: intent-aware image Q&A, long-screenshot OCR, UI reproduction, grounding, and pixel diff.",
-      "stars": 401,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 409,
+      "pushedAt": "2026-08-14T18:44:08Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "@dsh-external/dsh-vision-toolkit",
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "SPYQWER1/dsh-codex-tools",
@@ -2105,15 +2147,16 @@
       "fullName": "omdsh-dev/dsh-custom-tool",
       "url": "https://github.com/omdsh-dev/dsh-custom-tool",
       "description": "Create and manage sandboxed JavaScript tools with a Monaco editor and model-driven tool lifecycle.",
-      "stars": 23,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 24,
+      "pushedAt": "2026-08-13T15:11:37Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "ZRui-C/dsh-computer-use",
@@ -2134,14 +2177,15 @@
       "url": "https://github.com/Anionex/dsh-computer-use",
       "description": "Accessibility-first macOS computer use: fresh observations, stale-state rejection, scoped permissions, and safe input.",
       "stars": 20,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T12:53:56Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "kunjinkao-os/dsh-mobile-gui-agent",
@@ -2162,28 +2206,30 @@
       "url": "https://github.com/omdsh-dev/dsh-data-agent",
       "description": "Let the AI connect to databases and write SQL for you.",
       "stars": 25,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T16:59:42Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-toolkit",
       "url": "https://github.com/omdsh-dev/dsh-toolkit",
       "description": "Zero-dependency toolkit: time / encoding / json / calculator / csv / regex / markdown / diff / stat / schema — ten deterministic tools in one install.",
       "stars": 17,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:18Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "flymysql/dsh-remote",
@@ -2204,196 +2250,210 @@
       "url": "https://github.com/omdsh-dev/dsh-tool-csv",
       "description": "Parse/query/aggregate/convert CSV (RFC 4180) with a zero-dependency state-machine parser.",
       "stars": 4,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:10:56Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-calculator",
       "url": "https://github.com/omdsh-dev/dsh-tool-calculator",
       "description": "Safe math expression evaluator, zero-dependency recursive-descent parser.",
       "stars": 6,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:10:54Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-diff",
       "url": "https://github.com/omdsh-dev/dsh-tool-diff",
       "description": "Structured comparison and unified diffs for text/JSON/CSV/Markdown.",
       "stars": 4,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:10:59Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-encoding",
       "url": "https://github.com/omdsh-dev/dsh-tool-encoding",
       "description": "base64/url/hex encoding, common hashes, and UUID generation.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:01Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-json",
       "url": "https://github.com/omdsh-dev/dsh-tool-json",
       "description": "JSON queries with a JMESPath subset.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:04Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-markdown",
       "url": "https://github.com/omdsh-dev/dsh-tool-markdown",
       "description": "HTML↔Markdown conversion, GFM table normalization, and TOC generation.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:06Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-regex",
       "url": "https://github.com/omdsh-dev/dsh-tool-regex",
       "description": "Test/extract/safe-replace/statically explain regexes without executing code.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:09Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-schema",
       "url": "https://github.com/omdsh-dev/dsh-tool-schema",
       "description": "JSON Schema validation: validate/paths/explain/normalize.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:16Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-stat",
       "url": "https://github.com/omdsh-dev/dsh-tool-stat",
       "description": "Descriptive statistics, percentiles, frequency distributions, and correlation.",
       "stars": 4,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:13Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-tool-time",
       "url": "https://github.com/omdsh-dev/dsh-tool-time",
       "description": "Strict ISO 8601 parsing, IANA timezone conversion, and UTC calendar arithmetic.",
       "stars": 4,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:11Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-kb-sieve",
       "url": "https://github.com/omdsh-dev/dsh-kb-sieve",
       "description": "Build auditable KB packs (SQLite FTS5) from md/txt/docx/pdf with deterministic retrieval and original-text reading.",
       "stars": 2,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-12T06:59:40Z",
+      "license": "Apache-2.0",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "HuanLinOTO/dsh-plugin-mineru",
       "url": "https://github.com/HuanLinOTO/dsh-plugin-mineru",
       "description": "Expose MineRU document parsing tools to the model.",
-      "stars": 18,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 20,
+      "pushedAt": "2026-08-15T05:06:34Z",
+      "license": "NOASSERTION",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Jesse-njx/dsh-cowork",
       "url": "https://github.com/Jesse-njx/dsh-cowork",
       "description": "Bounded, cell-addressed `doc_read`/`doc_write` for xlsx / pdf / docx / pptx / ipynb, plus an MCP server and CLI.",
-      "stars": 2,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 3,
+      "pushedAt": "2026-08-13T16:58:50Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Jesse-njx/dsh-skillport",
       "url": "https://github.com/Jesse-njx/dsh-skillport",
       "description": "Bring your existing Agent Skills (SKILL.md) library to DSH: discover skills across Claude/Codex/Cursor/Gemini paths, inject a progressive-disclosure index, and load bodies on demand.",
       "stars": 2,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T17:07:52Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "sakikoTGW/pack-agent",
@@ -2414,42 +2474,45 @@
       "url": "https://github.com/vibeinging/dsh-tool-search",
       "description": "Per-agent on-demand tool discovery and progressive schema disclosure.",
       "stars": 2,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-12T13:18:45Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "THU-MAIC/dsh-openmaic",
       "url": "https://github.com/THU-MAIC/dsh-openmaic",
       "description": "OpenMAIC: classrooms, slides, interactive widgets, and Socratic teaching.",
       "stars": 8,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T13:27:52Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "lzszq/dsh-scholar",
       "url": "https://github.com/lzszq/dsh-scholar",
       "description": "Academic assistant plugin.",
       "stars": 15,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T13:04:39Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "ylwl1997/noatmark-dsh-plugin",
@@ -2470,14 +2533,15 @@
       "url": "https://github.com/jihongboo/dsh-apple-mode",
       "description": "Xcode AI integration for DSH: 26 Xcode MCP tools (mcpbridge) + Apple platform skills + Xcode Intelligence-style persona (agent preset or global bundle).",
       "stars": 1,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T17:35:12Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "ZK-Andy/dsh-continual-evolve",
@@ -2511,15 +2575,16 @@
       "fullName": "liustack/modlens",
       "url": "https://github.com/liustack/modlens",
       "description": "Vision bridge for text-only models: paste an image, get structured JSON evidence (OCR, layout, semantics).",
-      "stars": 1664,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 1736,
+      "pushedAt": "2026-08-14T20:36:33Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "@liustack/modlens",
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "dsh-market/dsh-market",
@@ -2819,15 +2884,16 @@
       "fullName": "liustack/modsearch",
       "url": "https://github.com/liustack/modsearch",
       "description": "Web search bridge for text-only agents: ask the web or X, get structured JSON evidence (search, fetch, citations).",
-      "stars": 103,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 104,
+      "pushedAt": "2026-08-15T05:18:00Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "@liustack/modsearch",
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "taxueseek/argo",
@@ -2861,15 +2927,16 @@
       "fullName": "Lum1104/dsh-browser",
       "url": "https://github.com/Lum1104/dsh-browser",
       "description": "Chrome sidebar extension that lets DSH operate your browser directly, no vision capabilities required.",
-      "stars": 133,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 140,
+      "pushedAt": "2026-08-15T10:07:22Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Sanqi-normal/dsh-webui-market-plugin",
@@ -2946,14 +3013,15 @@
       "url": "https://github.com/1na-ko/dsh-hdc-bridge",
       "description": "HarmonyOS device bridge: hdc screenshot/install/log/crash/UI automation loop with read_image, official-first versioned API knowledge (SDK .d.ts + offline bundled docs), and a DevEco CLI build/sign/lint lane.",
       "stars": 5,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T16:13:39Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "dsh-hdc-bridge",
       "category": {
         "id": "tools",
         "title": "工具与能力 / Tools & Capabilities"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "PicGo/dsh-plugin",
@@ -3225,15 +3293,16 @@
       "fullName": "dhicoc/dsh-reverse-skill",
       "url": "https://github.com/dhicoc/dsh-reverse-skill",
       "description": "Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.",
-      "stars": 13,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 12,
+      "pushedAt": "2026-08-15T08:07:53Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "skill",
         "title": "技能包 / Skills"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "creght-dev/skills",
@@ -3323,43 +3392,46 @@
       "fullName": "icetomoyo/dsh_workflow",
       "url": "https://github.com/icetomoyo/dsh_workflow",
       "description": "UltraCode-style multi-agent orchestration: a generatable, savable, governable, observable, resumable workflow layer.",
-      "stars": 55,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 56,
+      "pushedAt": "2026-08-13T23:53:40Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "NanmiCoder/dsh-agent-teams",
       "url": "https://github.com/NanmiCoder/dsh-agent-teams",
       "description": "AgentTeams multi-agent teams.",
-      "stars": 302,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 312,
+      "pushedAt": "2026-08-15T11:19:10Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "titanwings/dsh-automation",
       "url": "https://github.com/titanwings/dsh-automation",
       "description": "Scheduled coding runs in fresh agent sessions with auditable history.",
-      "stars": 37,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 39,
+      "pushedAt": "2026-08-14T06:43:27Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Sev7een/dsh-plugin-automations",
@@ -3380,112 +3452,120 @@
       "url": "https://github.com/Jesse-njx/dsh-routines",
       "description": "Scheduled agents on a cron: run a prompt on a schedule and get the digest where you already are, with overlap/missed-run/timeout safety defaults.",
       "stars": 1,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T16:59:52Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "titanwings/dsh-plannotator",
       "url": "https://github.com/titanwings/dsh-plannotator",
       "description": "Plan review with anchored annotations and structured feedback back to the agent.",
       "stars": 5,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T16:20:46Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "vlln/dsh-loop",
       "url": "https://github.com/vlln/dsh-loop",
       "description": "Recurring loops: `/loop` command + loop tool + activity status bar.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T14:22:09Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "fuhefei/dsh-sentinel",
       "url": "https://github.com/fuhefei/dsh-sentinel",
       "description": "Condition-driven wakeup: durable file/command/http/process/webhook watches that wake the agent.",
       "stars": 7,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T18:03:19Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-deep-research",
       "url": "https://github.com/omdsh-dev/dsh-deep-research",
       "description": "Adaptive deep-research orchestrator built on the official workflow engine.",
       "stars": 12,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-12T07:12:36Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-inspect",
       "url": "https://github.com/omdsh-dev/dsh-inspect",
       "description": "Adversarial checkup → fix → review loop toolset.",
       "stars": 5,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-12T07:03:13Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "fakechris/dsh-track",
       "url": "https://github.com/fakechris/dsh-track",
       "description": "Embedded task management engine: decision-point protocol, idea capture wall, Linear-style issue store.",
       "stars": 6,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T13:57:38Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "btspoony/dsh-advisor",
       "url": "https://github.com/btspoony/dsh-advisor",
       "description": "Pair a second model that passively reviews each turn and injects notes.",
       "stars": 9,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T11:35:26Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "lonelymoon87/dsh-specflow",
@@ -3547,15 +3627,16 @@
       "fullName": "btspoony/mstar-harness",
       "url": "https://github.com/btspoony/mstar-harness",
       "description": "Skill-driven harness/loop engineering workflow agent plugin.",
-      "stars": 45,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 46,
+      "pushedAt": "2026-08-15T13:33:02Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "workflow",
         "title": "工作流与自动化 / Workflow & Automation"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "LeslieWylie/dsh-ops-kit",
@@ -3701,43 +3782,46 @@
       "fullName": "omdsh-dev/dsh-open-in-vscode",
       "url": "https://github.com/omdsh-dev/dsh-open-in-vscode",
       "description": "Open DSH workspace directories in VS Code directly from the web GUI.",
-      "stars": 41,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 42,
+      "pushedAt": "2026-08-13T16:13:51Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-notification",
       "url": "https://github.com/omdsh-dev/dsh-notification",
       "description": "Desktop notifications for turn completions, with per-outcome controls and keyword rules.",
-      "stars": 45,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 47,
+      "pushedAt": "2026-08-13T15:28:50Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "bobleer/dsh-acp-for-bitfun",
       "url": "https://github.com/bobleer/dsh-acp-for-bitfun",
       "description": "ACP bridge between BitFun and DSH.",
       "stars": 9,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T13:38:31Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "openma-ai/deepseek-harness-acp",
@@ -3758,56 +3842,60 @@
       "url": "https://github.com/LoserFox/telegram",
       "description": "Bridge to the Telegram Bot API: long polling, per-chat sessions, HTML formatting.",
       "stars": 6,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-13T13:11:34Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Jesse-njx/dsh-chatnode-wechat",
       "url": "https://github.com/Jesse-njx/dsh-chatnode-wechat",
       "description": "Chat with, monitor, and approve your DSH agents from WeChat via the iLink gateway: text both ways, session targeting, digest heartbeats, and numbered approval prompts.",
       "stars": 2,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T16:55:50Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "dingyi222666/dsh-session-notification",
       "url": "https://github.com/dingyi222666/dsh-session-notification",
       "description": "Notifications for four session states, with browser alerts and prompts.",
-      "stars": 6,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "stars": 7,
+      "pushedAt": "2026-08-13T23:03:04Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "bill9109/dsh-web-ui-notify",
       "url": "https://github.com/bill9109/dsh-web-ui-notify",
       "description": "Desktop notification reminders.",
       "stars": 12,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T07:40:47Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "wsxwj123/dsh-plugins#pet-bridge",
@@ -3828,14 +3916,15 @@
       "url": "https://github.com/bill9109/dsh-webbridge",
       "description": "DSH meets Kimi WebBridge.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T08:04:17Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "BiBoyang/dsh-im-bridge",
@@ -3856,14 +3945,15 @@
       "url": "https://github.com/imetn/dsh-lark-bridge",
       "description": "Bidirectional Lark/Feishu controller for DeepSeek Harness with project and session routing, interactive cards, approvals, attachments, and task controls.",
       "stars": 7,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T06:53:32Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "notify",
         "title": "通知与集成 / Notifications & Integrations"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "yeruizhi/dsh-lark-meeting-notifier",
@@ -4038,14 +4128,15 @@
       "url": "https://github.com/btspoony/dsh-llm-fallbacks",
       "description": "Role-based LLM retry & fallback strategies.",
       "stars": 4,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T13:29:48Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "model",
         "title": "模型与账号接入 / Models & Providers"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "franksong2702/dsh-codex-connect",
@@ -4080,14 +4171,15 @@
       "url": "https://github.com/omdsh-dev/Qwen-MM-Plugins",
       "description": "Qwen multi-modal plugin support.",
       "stars": 4,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-09T10:59:51Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "model",
         "title": "模型与账号接入 / Models & Providers"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "suntianc/dsh-codex-auth",
@@ -4150,14 +4242,15 @@
       "url": "https://github.com/leechen298/Code2Skill",
       "description": "Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.",
       "stars": 2,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T01:25:54Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "bujue600-arch/dsh-testgen",
@@ -4178,42 +4271,45 @@
       "url": "https://github.com/omdsh-dev/fabric",
       "description": "An MC-Fabric-style hook processor.",
       "stars": 9,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-15T13:06:39Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "LoserFox/dsh-git-identity",
       "url": "https://github.com/LoserFox/dsh-git-identity",
       "description": "Pin Git commits to the environment's own author identity; env-var injection overrides all `git config` settings.",
       "stars": 7,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-13T13:11:37Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Zhenyu98/dsh-context-doctor",
       "url": "https://github.com/Zhenyu98/dsh-context-doctor",
       "description": "Context injection audit: token costs of instruction chains / skill catalogs / tool schemas, duplicate and conflict detection.",
       "stars": 7,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T16:29:47Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "ICCuse/dsh-pain-point-check",
@@ -4234,70 +4330,75 @@
       "url": "https://github.com/omdsh-dev/dsh-plugin-check",
       "description": "Plugin health checks: manifest protocol / patch format / build traps, zero-dependency and read-only.",
       "stars": 17,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:21Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-security-audit",
       "url": "https://github.com/omdsh-dev/dsh-security-audit",
       "description": "Local security audit: config, plugin origins, sessions, network exposure — read-only redacted risk report.",
       "stars": 11,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:28Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-session-health",
       "url": "https://github.com/omdsh-dev/dsh-session-health",
       "description": "Frame-level scan diagnostics for session files (torn/corrupt/empty detection).",
       "stars": 9,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T03:11:26Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "william-jin-cmu/dsh-evolve",
       "url": "https://github.com/william-jin-cmu/dsh-evolve",
       "description": "Self-evolution: the agent hot-mounts/removes persistent plugins on itself mid-session.",
       "stars": 5,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-13T02:26:42Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "vibeinging/dsh-trace",
       "url": "https://github.com/vibeinging/dsh-trace",
       "description": "Telemetry backend exporting turns, model steps, and tool calls to yiTrace.",
       "stars": 2,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-12T13:18:45Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "030611/dsh-telemetry-redactor",
@@ -4346,42 +4447,45 @@
       "url": "https://github.com/omdsh-dev/sandbox-micro",
       "description": "Support for the microsandbox backend.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-09T11:00:00Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/sandbox-mxc",
       "url": "https://github.com/omdsh-dev/sandbox-mxc",
       "description": "Microsoft cross-platform sandbox support.",
       "stars": 2,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-09T12:07:40Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/sandbox-nono",
       "url": "https://github.com/omdsh-dev/sandbox-nono",
       "description": "Support for the nono sandbox backend.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-11T06:32:44Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "vibeinging/dsh-agent-budget",
@@ -4402,28 +4506,30 @@
       "url": "https://github.com/Jesse-njx/dsh-polyglot",
       "description": "The model switch for DSH: point it at any OpenAI-compatible endpoint, with curated free/cheap DeepSeek provider presets and automatic fallback when a free tier rate-limits you.",
       "stars": 1,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T16:41:52Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "ilharp/dsh-tool-approval",
       "url": "https://github.com/ilharp/dsh-tool-approval",
       "description": "Manual approval mode (\"Manual Mode\" / \"Ask Mode\").",
       "stars": 1,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T13:06:38Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "arrow949/dsh-turn-approval",
@@ -4444,14 +4550,15 @@
       "url": "https://github.com/omdsh-dev/plugin-template",
       "description": "Plugin template repo (based on the official turtle-ui repo).",
       "stars": 5,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-12T20:17:02Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Small-tailqwq/dsh-tps",
@@ -4513,15 +4620,16 @@
       "fullName": "hust-open-atom-club/oh-dsh",
       "url": "https://github.com/hust-open-atom-club/oh-dsh",
       "description": "Community distribution: TUI, desktop, and Web UI as one bundle with layered installation.",
-      "stars": 181,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "stars": 184,
+      "pushedAt": "2026-08-15T13:43:12Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "BrambleXu/dsh-annotate",
@@ -4682,14 +4790,15 @@
       "url": "https://github.com/vlln/plugin-registry",
       "description": "Ecosystem infrastructure: a thin browser console for managing official repository plugins (zero patches) plus a make-dsh-plugin skill for guided plugin development.",
       "stars": 40,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T14:22:05Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "forrestchang/dsh-multica-runtime",
@@ -4738,14 +4847,15 @@
       "url": "https://github.com/slywalker2006/dsh-passwords",
       "description": "Login gateway for the DSH web UI: password door with first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF, anti-framing.",
       "stars": 3,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T13:52:26Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "dev",
         "title": "开发与运行时 / Development & Runtime"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Yuuz12/dsh-webui-auth",
@@ -4835,155 +4945,166 @@
       "fullName": "Nagi-ovo/dsh-ads",
       "url": "https://github.com/Nagi-ovo/dsh-ads",
       "description": "Parody ads in 2005-Chinese-web style: sidebar banners, in-chat feeds, corner popups, and a close button whose hit area is smaller than it looks. All fictional.",
-      "stars": 388,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 396,
+      "pushedAt": "2026-08-14T23:22:57Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-gomoku",
       "url": "https://github.com/omdsh-dev/dsh-gomoku",
       "description": "Play Gomoku against the AI, or let two AIs battle it out.",
       "stars": 13,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T05:42:26Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "AnacondaKC/dsh-stock-market",
       "url": "https://github.com/AnacondaKC/dsh-stock-market",
       "description": "Fixes the bug where your account can't lose money while you code.",
       "stars": 11,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T06:26:46Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "hellodigua/dsh-emoji",
       "url": "https://github.com/hellodigua/dsh-emoji",
       "description": "Automatically add emojis to AI replies.",
       "stars": 17,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T05:12:54Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "lhh010/dsh-minigames",
       "url": "https://github.com/lhh010/dsh-minigames",
       "description": "Side-panel arcade: 18 offline mini-games to play while the model thinks.",
       "stars": 18,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T13:53:38Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "william-jin-cmu/dsh-stickers",
       "url": "https://github.com/william-jin-cmu/dsh-stickers",
       "description": "Bidirectional sticker reactions between user and agent.",
-      "stars": 15,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 16,
+      "pushedAt": "2026-08-13T02:26:59Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "vlln/whale-girl",
       "url": "https://github.com/vlln/whale-girl",
       "description": "Desktop pet (QQ-pet style): floats in the corner, draggable, feedable, playable.",
-      "stars": 159,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "stars": 160,
+      "pushedAt": "2026-08-13T14:22:20Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "Moeblack/deepseek-manners",
       "url": "https://github.com/Moeblack/deepseek-manners",
       "description": "Append a thank-you note after every message. Mind your manners.",
       "stars": 10,
-      "pushedAt": "2026-08-13T00:00:00Z",
+      "pushedAt": "2026-08-13T13:48:49Z",
       "license": null,
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "HuanLinOTO/dsh-plugin-d399",
       "url": "https://github.com/HuanLinOTO/dsh-plugin-d399",
       "description": "Pops up a mini-game menu (wordle, match-3, extensible) while the model generates.",
       "stars": 5,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-15T09:05:58Z",
+      "license": "NOASSERTION",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "omdsh-dev/dsh-auto-chess",
       "url": "https://github.com/omdsh-dev/dsh-auto-chess",
       "description": "Auto chess: human vs AI, or AI vs AI.",
       "stars": 3,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T09:29:29Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "AnacondaKC/dsh-douyin",
       "url": "https://github.com/AnacondaKC/dsh-douyin",
       "description": "Short-video sidebar: native player, series navigation, precise history replay.",
       "stars": 2,
-      "pushedAt": "2026-08-13T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-13T06:26:44Z",
+      "license": "BSD-3-Clause",
       "isPlugin": true,
       "npmName": null,
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "minybear/DeepSeek-Harness-Pet",
@@ -5004,14 +5125,15 @@
       "url": "https://github.com/anweat/dsh-web-search-pro",
       "description": "Persistent enhanced web search: multi-engine routing (DeepSeek/Exa/DDG/Bing/Jina + GitHub/Bilibili/YouTube/V2EX/Xiaohongshu/Twitter/Reddit/RSS), SQLite+LRU cache, userscript-style extraction, Playwright rendering.",
       "stars": 7,
-      "pushedAt": "2026-08-14T00:00:00Z",
-      "license": null,
+      "pushedAt": "2026-08-14T08:07:39Z",
+      "license": "MIT",
       "isPlugin": true,
       "npmName": "dsh-web-search-pro",
       "category": {
         "id": "fun",
         "title": "娱乐 / Just for Fun"
-      }
+      },
+      "archived": false
     },
     {
       "fullName": "anweat/dsh-browser",

--- a/docs/reconcile.md
+++ b/docs/reconcile.md
@@ -2,9 +2,9 @@
 
 > 由 `node scripts/reconcile.mjs` 生成。对比 `data/plugins.json`（种子数据）与 `plugins/*.md`（目录清单）。
 >
-> 数据共 365 条 · 目录共 297 条 · 两者交集 122 条
+> 数据共 365 条 · 目录共 295 条 · 两者交集 119 条
 
-## 候选待收录（数据里有、目录还没有）— 243 条
+## 候选待收录（数据里有、目录还没有）— 246 条
 
 按 star 降序。可作为下一步补录清单。
 
@@ -32,11 +32,13 @@
 | [yuezengwu/dsh-explain](https://github.com/yuezengwu/dsh-explain) | 10 | 会话与消息 / Sessions & Messages |
 | [KinGao294/dsh-skin](https://github.com/KinGao294/dsh-skin) | 9 | 主题与外观 / Themes & Appearance |
 | [linenxi-ctrl/dsh-vision](https://github.com/linenxi-ctrl/dsh-vision) | 9 | 工具与能力 / Tools & Capabilities |
+| [btspoony/dsh-advisor](https://github.com/btspoony/dsh-advisor) | 9 | 工作流与自动化 / Workflow & Automation |
 | [biociao/dsh-science](https://github.com/biociao/dsh-science) | 9 | 工作流与自动化 / Workflow & Automation |
 | [PC2005-cloud/dsh-pet#dsh-pet](https://github.com/PC2005-cloud/dsh-pet/tree/main/dsh-pet) | 9 | 娱乐 / Just for Fun |
 | [Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) | 8 | UI 增强 / UI Enhancements |
 | [01Virex/dsh-status-rotator](https://github.com/01Virex/dsh-status-rotator) | 8 | UI 增强 / UI Enhancements |
 | [modusensus/dsh-mneme](https://github.com/modusensus/dsh-mneme) | 8 | 记忆 / Memory |
+| [Buyi-wsgzg/dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) | 7 | 会话与消息 / Sessions & Messages |
 | [creght-dev/skills](https://github.com/creght-dev/skills) | 7 | 技能包 / Skills |
 | [Areium/dsh-fail-logger](https://github.com/Areium/dsh-fail-logger) | 7 | 开发与运行时 / Development & Runtime |
 | [Sev7een/ds-api-usage](https://github.com/Sev7een/ds-api-usage) | 6 | UI 增强 / UI Enhancements |
@@ -57,6 +59,7 @@
 | [MorGogh/widget-dock](https://github.com/MorGogh/widget-dock) | 4 | UI 增强 / UI Enhancements |
 | [heartmove/dsh-side-chat](https://github.com/heartmove/dsh-side-chat) | 4 | 会话与消息 / Sessions & Messages |
 | [PicGo/dsh-plugin](https://github.com/PicGo/dsh-plugin) | 4 | 工具与能力 / Tools & Capabilities |
+| [btspoony/dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) | 4 | 模型与账号接入 / Models & Providers |
 | [feibi-mochi/deepseek-harness-wallet](https://github.com/feibi-mochi/deepseek-harness-wallet) | 4 | 模型与账号接入 / Models & Providers |
 | [030611/qiushi-dsh-evidence-audit](https://github.com/030611/qiushi-dsh-evidence-audit) | 4 | 开发与运行时 / Development & Runtime |
 | [Yuuz12/dsh-webui-auth](https://github.com/Yuuz12/dsh-webui-auth) | 4 | 开发与运行时 / Development & Runtime |
@@ -254,7 +257,7 @@
 | [jiayan-xu/dsh-ocr-review](https://github.com/jiayan-xu/dsh-ocr-review) | 0 | 开发与运行时 / Development & Runtime |
 | [anweat/dsh-voice-webspeech](https://github.com/anweat/dsh-voice-webspeech) | 0 | 娱乐 / Just for Fun |
 
-## 目录里有、数据里没有 — 175 条
+## 目录里有、数据里没有 — 176 条
 
 多为官方/元项目、dsh-external 私有仓库、或来自其他来源的补充条目，需人工确认是否保留。
 
@@ -307,15 +310,14 @@
 - `bittersmilezzz/dsh-model-selector` — 🎨 Web UI / 皮肤 / 主题
 - `mongfayi/dsh-local-filetree` — 🎨 Web UI / 皮肤 / 主题
 - `hashdiana/dsh-token-usage` — 🎨 Web UI / 皮肤 / 主题
-- `liangyin233/dsh-model-config-sync` — 🎨 Web UI / 皮肤 / 主题
+- `liangyin233/dsh-provider-model-configurator` — 🎨 Web UI / 皮肤 / 主题
 - `zhu1090093659/dsh-web-ui` — 🎨 Web UI / 皮肤 / 主题
 - `lqhl/dsh-pi-tui` — 🖥️ 桌面端 / TUI / 移动端
 - `gxinxing/deepseek-harness-tui` — 🖥️ 桌面端 / TUI / 移动端
 - `orriduck/dsh-tui` — 🖥️ 桌面端 / TUI / 移动端
-- `openguardrails/dsh-tui` — 🖥️ 桌面端 / TUI / 移动端
-- `hust-open-atom-club/oh-dsh-desktop` — 🖥️ 桌面端 / TUI / 移动端
+- `dsh-tui/dsh-tui` — 🖥️ 桌面端 / TUI / 移动端
 - `chyra-moon/deepseek-harness-desktop` — 🖥️ 桌面端 / TUI / 移动端
-- `easyhoov/deepseek-harness-desktop` — 🖥️ 桌面端 / TUI / 移动端
+- `easyhoov/deepseek-harness-desktop-windows` — 🖥️ 桌面端 / TUI / 移动端
 - `bruc3van/dsh-desktop` — 🖥️ 桌面端 / TUI / 移动端
 - `zsyu9779/dsh-desktop` — 🖥️ 桌面端 / TUI / 移动端
 - `mrbbbaixue/dsh-desktop` — 🖥️ 桌面端 / TUI / 移动端
@@ -326,17 +328,17 @@
 - `anywhere-labs/deepseek-harness-desktop` — 🖥️ 桌面端 / TUI / 移动端
 - `chisaalter/deepseek-harness-desktop` — 🖥️ 桌面端 / TUI / 移动端
 - `ruler4396/dsh-launcher` — 🖥️ 桌面端 / TUI / 移动端
-- `vibeinging/dsh-work` — 🖥️ 桌面端 / TUI / 移动端
+- `vibeinging/deepseek-harness-desktop-app` — 🖥️ 桌面端 / TUI / 移动端
 - `william-jin-cmu/dsh-companion` — 🖥️ 桌面端 / TUI / 移动端
 - `dsh-external/dsh-mobileweb-adapter` — 🖥️ 桌面端 / TUI / 移动端
-- `dsh-external/dsh-mobile` — 🖥️ 桌面端 / TUI / 移动端
+- `lehhair/dsh-mobile` — 🖥️ 桌面端 / TUI / 移动端
 - `dsh-external/dsh-android` — 🖥️ 桌面端 / TUI / 移动端
 - `jiruidai/dsh-meta-orchestrator` — 🤖 Agent 编排 / 多 Agent
 - `happyren/dsh-agent-messaging` — 🤖 Agent 编排 / 多 Agent
 - `asaiuta/dsh-session-hub` — 🤖 Agent 编排 / 多 Agent
 - `huanlinoto/dsh-plugin-yet-another-subagent` — 🤖 Agent 编排 / 多 Agent
 - `dsh-external/dsh-plan-execute` — 🤖 Agent 编排 / 多 Agent
-- `dsh-external/dsh-a2a` — 🤖 Agent 编排 / 多 Agent
+- `dpskh/dsh-a2a` — 🤖 Agent 编排 / 多 Agent
 - `dsh-external/dsh-subagent-tree` — 🤖 Agent 编排 / 多 Agent
 - `dsh-external/dsh-teamwork` — 🤖 Agent 编排 / 多 Agent
 - `csyangwen/dsh-memory-evolve` — 🧠 上下文 / 记忆
@@ -348,6 +350,7 @@
 - `dsh-external/dsh-easy-ctx-manager` — 🧠 上下文 / 记忆
 - `linglambda/dsh-undo` — 🧠 上下文 / 记忆
 - `mongfayi/dsh-recall` — 🧠 上下文 / 记忆
+- `omdsh-dev/dsh-sidechain` — 🧠 上下文 / 记忆
 - `tieboyh/dsh-session-search` — 🧠 上下文 / 记忆
 - `perrylink/dsh-claude-move` — 🧠 上下文 / 记忆
 - `anionex/agent-vision-toolkit` — 👁️ 多模态 / 视觉
@@ -361,6 +364,8 @@
 - `pangyiming/dsh-mobile-control` — 👁️ 多模态 / 视觉
 - `huanlinoto/dsh-plugin-aigc-canvas` — 👁️ 多模态 / 视觉
 - `havingautism/dsh-deepresearch` — 🔁 工作流 / 自动化
+- `omdsh-dev/dsh-advisor` — 🔁 工作流 / 自动化
+- `omdsh-dev/dsh-llm-fallbacks` — 🔁 工作流 / 自动化
 - `humblebanana/dsh-record-replay` — 🔁 工作流 / 自动化
 - `omdsh-dev/dsh-daily-progress` — 🔁 工作流 / 自动化
 - `karloflaw/dsh-goal-mode-enhance` — 🔁 工作流 / 自动化
@@ -386,7 +391,6 @@
 - `crayonlu/dsh-web-search-tavily` — 🌐 浏览器 / 搜索
 - `zhouzhencheng07/dsh-tavily-search` — 🌐 浏览器 / 搜索
 - `realalexandreai/dsh-all-search` — 🌐 浏览器 / 搜索
-- `dsh-external/plugin-registry` — 🏗️ 基础设施 / 插件管理 / 开发工具
 - `jesse-njx/dsh-plugin-manager-registry` — 🏗️ 基础设施 / 插件管理 / 开发工具
 - `omdsh-dev/dsh-hub` — 🏗️ 基础设施 / 插件管理 / 开发工具
 - `nexus-aethra/dsh-plugin-switch` — 🏗️ 基础设施 / 插件管理 / 开发工具

--- a/plugins/agent-orchestration.md
+++ b/plugins/agent-orchestration.md
@@ -2,18 +2,18 @@
 
 > **多 Agent 与编排**：Agent 团队、plan/execute 路由、A2A、meta-orchestrator、跨会话消息。返回 [目录](../README.md#分类目录)
 
-- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) — AgentTeams 多智能体团队协作 ⭐302 · `dsh plugin add dsh-agent-teams`
-- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — 把 UltraCode 式多 Agent 调度带给 DSH：可生成/保存/治理/观察/恢复的 Workflow 层 ⭐55 · `dsh plugin add @dsh-external/workflow`
+- [dsh-agent-teams](https://github.com/NanmiCoder/dsh-agent-teams) — AgentTeams 多智能体团队协作 ⭐312 · `dsh plugin add dsh-agent-teams`
+- [dsh_workflow](https://github.com/icetomoyo/dsh_workflow) — 把 UltraCode 式多 Agent 调度带给 DSH：可生成/保存/治理/观察/恢复的 Workflow 层 ⭐56 · `dsh plugin add @dsh-external/workflow`
 - [dsh-meta-orchestrator](https://github.com/jiruidai/dsh-meta-orchestrator) — 模型原生 meta-agent：运行时合成任务专属工作流并协调工具/子代理 ⭐3 · `dsh plugin add dsh-meta-orchestrator`
 - [dsh-crosstalk](https://github.com/Jesse-njx/dsh-crosstalk) — 跨会话消息互发：本机任意会话像 Claude Code 一样互发消息 ⭐2 · `dsh plugin add @dsh-crosstalk/bundle`
 - [dsh-agent-messaging](https://github.com/happyren/dsh-agent-messaging) — 跨会话 agent-to-agent 消息投递（按会话名寻址） ⭐4 · `dsh plugin add dsh-agent-messaging`
-- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) — 跨实例消息/事件交接（interconnect 服务 + 工具） ⭐26 · `dsh plugin add dsh-interconnect`
+- [dsh-interconnect](https://github.com/Chinesezjc/dsh-interconnect) — 跨实例消息/事件交接（interconnect 服务 + 工具） ⭐27 · `dsh plugin add dsh-interconnect`
 - [dsh-session-hub](https://github.com/Asaiuta/dsh-session-hub) — 多服务器 DSH 会话聚合与原生操控（hub 网关 + 官方 UI 桥） ⭐3 · `dsh plugin add dsh-session-hub`
 - [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) — 可配置子代理 profiles + 实时工具调用/token 显示 + 子会话跳转 ⭐7 · `dsh plugin add @huanlin/dsh-plugin-yet-another-subagent`
-- [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) — 双模型 plan/execute 路由（planner 想、executor 做）⚠️ dsh-external，公开性待核实
-- [dsh-a2a](https://github.com/dsh-external/dsh-a2a) — Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 ⭐4
-- [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) — 子代理树可视化 ⚠️ dsh-external，公开性待核实
-- [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) — 团队协作（cordis）⚠️ dsh-external，公开性待核实
+- [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) — 双模型 plan/execute 路由（planner 想、executor 做）⚠️ dsh-external，已删除
+- [dsh-a2a](https://github.com/dpskh/dsh-a2a) — Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 ⭐4
+- [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) — 子代理树可视化 ⚠️ dsh-external，已删除
+- [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) — 团队协作（cordis）⚠️ dsh-external，已删除
 
 <!-- nav:start -->
 ---

--- a/plugins/browser-search.md
+++ b/plugins/browser-search.md
@@ -4,7 +4,7 @@
 
 ## 浏览器操控
 
-- [dsh-browser](https://github.com/Lum1104/dsh-browser) — Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） ⭐133
+- [dsh-browser](https://github.com/Lum1104/dsh-browser) — Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） ⭐140
 - [dsh-browser-control](https://github.com/PangYiMing/dsh-browser-control) — CDP/Playwright 操控浏览器 ⭐1 · `dsh plugin add dsh-browser-control`
 - [ego-browser](https://github.com/Fisfzy/ego-browser) — 把 ego-lite（给 AI Agent 的 Chromium）接入 DSH，13 个结构化 ego_* 工具 ⭐13
 - [dsh-better-browser](https://github.com/titanwings/dsh-better-browser) — 通过 Kimi WebBridge 让 Agent 操作用户已登录浏览器（13 个工具） ⭐7 · `dsh plugin add @dsh-external/dsh-better-browser`
@@ -16,13 +16,13 @@
 
 ## 搜索 / 抓取
 
-- [dsh-webfetch](https://github.com/withlovehub/dsh-webfetch) — 零依赖 webfetch MCP server（robots 合规、SSRF 防护） ⭐2
 - [dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) — Firecrawl 搜索提供方接入内置 web_search ⭐2 · `dsh plugin add @yangzhe1003/dsh-web-search-firecrawl`
 - [dsh-web-search-tavily](https://github.com/crayonlu/dsh-web-search-tavily) — Tavily 搜索提供方（免 DeepSeek key） ⭐3
 - [dsh-tavily-search](https://github.com/zhouzhencheng07/dsh-tavily-search) — 免 key Tavily 搜索工具 ⭐2 · `dsh plugin add dsh-tavily-search`
 - [dsh-web-search-pro](https://github.com/anweat/dsh-web-search-pro) — 增强持久搜索（多引擎 + SQLite/LRU 缓存 + Playwright 渲染） ⭐7 · `dsh plugin add dsh-web-search-pro`
 - [dsh-all-search](https://github.com/RealAlexandreAI/dsh-all-search) — AnySearch 网页搜索提供方（ctx.web） ⭐1 · `dsh plugin add dsh-all-search`
-- [modsearch](https://github.com/liustack/modsearch) — CLI 搜索工具：把搜索查询转结构化 web 证据 JSON ⭐103 · `dsh plugin add @liustack/modsearch`
+- [modsearch](https://github.com/liustack/modsearch) — CLI 搜索工具：把搜索查询转结构化 web 证据 JSON ⭐104 · `dsh plugin add @liustack/modsearch`
+- [argo](https://github.com/taxueseek/argo) — 为 agent 打造的多语言搜索工具（中文/英文/学术/代码/购物/金融/新闻/百科） ⭐77 · `dsh plugin add github:taxueseek/argo`
 
 <!-- nav:start -->
 ---

--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -4,11 +4,11 @@
 
 ## 记忆 / 知识
 
-- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) — 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） ⭐76
+- [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) — 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） ⭐82
 - [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) — 模型驱动上下文压缩（ACP）：模型决定何时压缩（移植自 billion-context-pi） ⭐12
 - [dsh-memory](https://github.com/Jesse-njx/dsh-memory) — 基于无损会话日志的引用式记忆（事实带 sessionId/eventRange 引用） ⭐2 · `dsh plugin add @dsh-memory/bundle`
 - [dsh-memory](https://github.com/ben7am1n/dsh-memory) — 跨会话 SQLite 持久记忆 ⭐1 · `dsh plugin add dsh-memory`
-- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Mnemon 本地三层记忆（Runtime Memory/可检索文档/受监督 Memory Spaces） ⭐25 · `dsh plugin add dsh-mnemon`
+- [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Mnemon 本地三层记忆（Runtime Memory/可检索文档/受监督 Memory Spaces） ⭐26 · `dsh plugin add dsh-mnemon`
 - [nowledge-mem-deepseek-harness](https://github.com/nowledge-co/nowledge-mem-deepseek-harness) — 给所有 AI 工具共用的一层记忆（Context Bundle 注入 + MCP 工具 + 线程捕获） ⭐5 · `dsh plugin add nowledge-mem-deepseek-harness`
 - [dsh-plugin-meta-memory](https://github.com/YYTbit/dsh-plugin-meta-memory) — 结构化长期记忆系统 ⭐2 · `dsh plugin add dsh-plugin-meta-memory`
 - [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) — 从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5） ⭐2 · `dsh plugin add @dsh-external/dsh-kb-sieve`
@@ -20,16 +20,16 @@
 - [context-vista](https://github.com/GooodWei/context-vista) — `/context` 命令 + 环形图实时展示上下文 token 用量与费用 ⭐4 · `dsh plugin add context-vista`
 - [distill](https://github.com/LoserFox/distill) — 自动对话蒸馏：后台 subagent 反省 + 技能 create/update ⭐17 · `dsh plugin add @loserfox/distill`
 - [dsh-auto-compact](https://github.com/wangxiang0605qvq/dsh-auto-compact) — compact_now 工具，回合结束自动压缩上下文
-- [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) — 上下文管理：节省、注意力优化、压缩档案馆 ⚠️ dsh-external，公开性待核实
-- [dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：展示模型上下文窗口的构成与演化 ⭐38 · `dsh plugin add dsh-context`
+- [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) — 上下文管理：节省、注意力优化、压缩档案馆 ⚠️ dsh-external，已删除
+- [dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：展示模型上下文窗口的构成与演化 ⭐40 · `dsh plugin add dsh-context`
 
 ## 会话控制 / 回退
 
 - [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) — 对话回退：基于持久 Change Ledger 回滚会话与工作区状态 ⭐50 · `dsh plugin add @dsh-external/turn-rewind`
 - [dsh-undo](https://github.com/LingLambda/dsh-undo) — 上下文 undo/redo：回退到上一个已完成步骤并恢复 ⭐3 · `dsh plugin add dsh-undo`
 - [dsh-recall](https://github.com/Mongfayi/dsh-recall) — 消息撤回：每条用户消息一个撤销按钮，删除该轮及其后内容（不改代码） ⭐3 · `dsh plugin add dsh-recall`
-- [dsh-sidechain](https://github.com/Buyi-wsgzg/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行 ⭐6 · `dsh plugin add @dsh-external/dsh-sidechain`
-- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线 ⭐20 · `dsh plugin add dsh-message-edit`
+- [dsh-sidechain](https://github.com/omdsh-dev/dsh-sidechain) — `/side` 持续性侧会话与 `/btw` 一次性侧问，在临时 fork 中运行 ⭐7 · `dsh plugin add @dsh-external/dsh-sidechain`
+- [dsh-message-edit](https://github.com/Moeblack/dsh-message-edit) — 基于分支的消息编辑、reroll、重试与版本时间线 ⭐21 · `dsh plugin add dsh-message-edit`
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) — 跨 dsh/Codex/Claude/pi/OpenCode 会话的无索引全文搜索 ⭐2
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话 ⭐29 · `dsh plugin add dsh-chat-import`
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) — 迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH ⭐3 · `dsh plugin add dsh-claude-move`

--- a/plugins/desktop-tui-mobile.md
+++ b/plugins/desktop-tui-mobile.md
@@ -6,43 +6,43 @@
 
 ## 终端 TUI
 
-- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) — Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 ⭐1120 · `dsh plugin add dsh-cc-tui`
-- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) — DSH 终端 TUI（天枢） ⭐149 · `dsh plugin add @huiliyi37/dsh-tianshu-tui`
+- [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) — Claude Code 风格全屏交互终端：像素鲸鱼顶栏、流式思考展开、双击 Esc 回滚、上下文/TPS 仪表 ⭐1157 · `dsh plugin add dsh-cc-tui`
+- [dsh-tianshu-tui](https://github.com/huiliyi37/dsh-tianshu-tui) — DSH 终端 TUI（天枢） ⭐153 · `dsh plugin add @huiliyi37/dsh-tianshu-tui`
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) — Pi TUI 前端：流式 markdown、思考折叠、工具卡、斜杠命令 ⭐1
 - [deepseek-harness-tui](https://github.com/gxinxing/deepseek-harness-tui) — Ink/React 终端原生 TUI ⭐7 · `dsh plugin add deepseek-harness-tui`
 - [dsh-tui](https://github.com/orriduck/dsh-tui) — 轻量、会话感知的终端 UI ⭐2 · `dsh plugin add dsh-tui`
-- [dsh-tui](https://github.com/openguardrails/dsh-tui) — Claude Code 风格终端 UI（out-of-tree bundle） ⭐15 · `dsh plugin add @openguardrails/dsh-tui`
+- [dsh-tui](https://github.com/dsh-tui/dsh-tui) — Claude Code 风格终端 UI（out-of-tree bundle） ⭐15 · `dsh plugin add @dsh-tui/dsh-tui`
 
 ## 社区发行版
 
-- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) — 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验 ⭐181 · `dsh plugin add @oh-dsh/desktop`
-- [oh-dsh-desktop](https://github.com/hust-open-atom-club/oh-dsh-desktop) — 可扩展 macOS 工作台：原生 PTY、工作区工具、双语插件、隔离预览市场 ⭐181
+- [oh-dsh](https://github.com/hust-open-atom-club/oh-dsh) — 一站式社区发行版：TUI、桌面端与 Web UI 三种形态统一体验 ⭐184 · `dsh plugin add @oh-dsh/desktop`
 
 ## 桌面壳（多作者）
 
 - [deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) — Windows 原生桌面壳：1:1 官方 Web UI + 内置服务器托管 + 托盘驻留 ⭐10
-- [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) — 非官方进程内 Windows 桌面应用（托盘 + 原生通知 + IPC） ⭐1
-- [dsh-desktop](https://github.com/bruc3van/dsh-desktop) — 社区维护的非官方桌面客户端（复用官方实例或内置运行时） ⭐25
+- [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop-windows) — 非官方进程内 Windows 桌面应用（托盘 + 原生通知 + IPC） ⭐1
+- [dsh-desktop](https://github.com/bruc3van/dsh-desktop) — 社区维护的非官方桌面客户端（复用官方实例或内置运行时） ⭐29
 - [dsh-desktop](https://github.com/zsyu9779/dsh-desktop) — Wails(Go) 桌面壳，Codex 风格原生应用 ⭐4
 - [dsh-desktop](https://github.com/mrbbbaixue/dsh-desktop) — .NET 10 WPF + WebView2 桌面启动器 ⭐2
-- [dsh-desktop](https://github.com/dataelement/dsh-desktop) — 跨平台桌面应用 ⭐217
+- [dsh-desktop](https://github.com/dataelement/dsh-desktop) — 跨平台桌面应用 ⭐221
 - [dsh-desktop-electron](https://github.com/Void0312Aurora/dsh-desktop-electron) — 跨平台 Electron 桌面壳（托盘驻留、无内置 Node） ⭐4
-- [dsh-mac-desktop](https://github.com/bitterSmilezzz/dsh-mac-desktop) — 在原生 macOS 窗口打开 Web GUI（SwiftUI + WKWebView） ⭐2 · `dsh plugin add dsh-mac-desktop`
+- [dsh-mac-desktop](https://github.com/bitterSmilezzz/dsh-mac-desktop) — 在原生 macOS 窗口打开 Web GUI（SwiftUI + WKWebView）（已删除） ⭐2 · `dsh plugin add dsh-mac-desktop`
 - [dsh-desktop-window](https://github.com/fengzhiyushui/dsh-desktop-window) — 以独立应用窗口打开 Web UI（自动开窗 + 设置开关） ⭐1 · `dsh plugin add dsh-desktop-window`
-- [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) — 现代化 DeepSeek Harness 桌面端体验 ⭐4287
-- [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) — Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web ⭐80 · `dsh plugin add deepseek-harness-desktop`
-- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) — Windows 轻量启动器：开机自启 + 独立小窗口 ⭐89
+- [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) — 现代化 DeepSeek Harness 桌面端体验 ⭐4668
+- [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) — Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web ⭐81 · `dsh plugin add deepseek-harness-desktop`
+- [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) — Windows 轻量启动器：开机自启 + 独立小窗口 ⭐92
 
 ## 本地工作台
 
-- [dsh-work](https://github.com/vibeinging/dsh-work) — 本地 AI 工作桌面：Session/文件/数据分析/MCP/Office 一体化 ⭐115
+- [dsh-work](https://github.com/vibeinging/deepseek-harness-desktop-app) — 本地 AI 工作桌面：Session/文件/数据分析/MCP/Office 一体化 ⭐115
 
 ## 移动端 / 常驻助手
 
 - [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) — 常驻桌面助手：全局唤起、定时自动化、快捷回复、插件市场 ⭐5
-- [dsh-mobileweb-adapter](https://github.com/dsh-external/dsh-mobileweb-adapter) — 手机 Web 适配器：让 Web GUI 在手机上可用（⚠️ dsh-external，公开性待核实）
-- [dsh-mobile](https://github.com/dsh-external/dsh-mobile) — 移动端客户端（⚠️ dsh-external，公开性待核实） ⭐12
-- [dsh-android](https://github.com/dsh-external/dsh-android) — 在 Android 上运行 dsh（⚠️ dsh-external，公开性待核实）
+- [dsh-mobileweb-adapter](https://github.com/dsh-external/dsh-mobileweb-adapter) — 手机 Web 适配器：让 Web GUI 在手机上可用（⚠️ dsh-external，已删除）
+- [dsh-mobile](https://github.com/lehhair/dsh-mobile) — 移动端客户端（⚠️ dsh-external，公开性待核实） ⭐12
+- [dsh-android](https://github.com/dsh-external/dsh-android) — 在 Android 上运行 dsh（⚠️ dsh-external，已删除）
+- [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — Rust/ratatui 编写的 DSH 终端 TUI ⭐25 · `dsh plugin add github:openma-ai/deepseek-harness-tui`
 
 <!-- nav:start -->
 ---

--- a/plugins/fun-other.md
+++ b/plugins/fun-other.md
@@ -12,16 +12,16 @@
 ## 桌宠 / 表情 / 贴纸
 
 - [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) — 全手绘像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心） ⭐30
-- [whale-girl](https://github.com/vlln/whale-girl) — 桌面宠物鲸鱼娘（QQ 宠物形态，可拖拽/投喂/玩耍） ⭐159 · `dsh plugin add whale-girl`
+- [whale-girl](https://github.com/vlln/whale-girl) — 桌面宠物鲸鱼娘（QQ 宠物形态，可拖拽/投喂/玩耍） ⭐160 · `dsh plugin add whale-girl`
 - [dsh-pixel-whale](https://github.com/yoke233/dsh-pixel-whale) — 活泼像素鲸鱼运行状态伴侣 ⭐1 · `dsh plugin add dsh-pixel-whale`
 - [dsh-blue-whale-maid](https://github.com/yuxino/dsh-blue-whale-maid) — 蓝鲸女仆桌面像素宠物 ⭐3 · `dsh plugin add dsh-blue-whale-maid`
-- [deepseek-pet](https://github.com/keleus/deepseek-pet) — 在 DSH 上养一只大蓝鲸 ⭐15 · `dsh plugin add deepseek-pet`
-- [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) — 用户与 agent 双向表情贴纸互动 ⭐15 · `dsh plugin add @dsh-external/dsh-stickers`
+- [deepseek-pet](https://github.com/keleus/deepseek-pet) — 在 DSH 上养一只大蓝鲸 ⭐18 · `dsh plugin add deepseek-pet`
+- [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) — 用户与 agent 双向表情贴纸互动 ⭐16 · `dsh plugin add @dsh-external/dsh-stickers`
 - [dsh-emoji](https://github.com/hellodigua/dsh-emoji) — 为 AI 回复自动添加表情 ⭐17 · `dsh plugin add @dsh-external/dsh-emoji`
 
 ## 整活 / 音效 / 趣味
 
-- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — 2005 中文站点风格整活广告（侧栏/信息流/弹窗，素材全虚构） ⭐388 · `dsh plugin add @dsh-external/dsh-ads`
+- [dsh-ads](https://github.com/Nagi-ovo/dsh-ads) — 2005 中文站点风格整活广告（侧栏/信息流/弹窗，素材全虚构） ⭐396 · `dsh plugin add @dsh-external/dsh-ads`
 - [dsh-stock-market](https://github.com/AnacondaKC/dsh-stock-market) — 股票行情数据插件（整活向） ⭐11 · `dsh plugin add dsh-stock-market`
 - [dsh-douyin](https://github.com/AnacondaKC/dsh-douyin) — 侧栏短视频：原生播放器、系列导航、历史回放 ⭐2 · `dsh plugin add dsh-douyin`
 - [deepseek-manners](https://github.com/Moeblack/deepseek-manners) — 每次消息后注入感谢语，做个有礼貌的人 ⭐10 · `dsh plugin add deepseek-manners`
@@ -29,7 +29,7 @@
 - [dsh-fun-typewriter](https://github.com/omdsh-dev/dsh-fun-typewriter) — WebAudio 打字机氛围音效（零音频资源） ⭐3 · `dsh plugin add @deepseek-ai/dsh-fun-typewriter`
 - [dsh-daily-fortune](https://github.com/omdsh-dev/dsh-daily-fortune) — 每日运势：观音签、塔罗、每日一句 ⭐3 · `dsh plugin add @deepseek-ai/dsh-daily-fortune`
 - [dsh-plugin-spur](https://github.com/HuanLinOTO/dsh-plugin-spur) — 挂在聊天流里的辫子，抓住甩一甩给 agent 发「去干活」 ⭐3 · `dsh plugin add @huanlin/dsh-plugin-spur`
-- [dsh-toy](https://github.com/c3ll256/dsh-toy) — 连接小型玩具到 DSH（Toy Control Protocol） ⭐38 · `dsh plugin add dsh-toy`
+- [dsh-toy](https://github.com/c3ll256/dsh-toy) — 连接小型玩具到 DSH（Toy Control Protocol） ⭐43 · `dsh plugin add dsh-toy`
 
 ## 教学 / 学习 / 研究
 
@@ -41,9 +41,12 @@
 
 ## 设计 / 垂直创作
 
-- [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) — OpenPencil 设计预览与编辑（Agent 操作真实设计画布） ⭐74 · `dsh plugin add @zseven-w/dsh-openpencil`
 - [dsh-director-toolkit](https://github.com/lhmd/dsh-director-toolkit) — 3D 艺术家/技术美术方向包：Blender/Three.js/Houdini/C4D 方向指引 ⭐7 · `dsh plugin add @lhmd/dsh-director-toolkit`
 - [dsh-apple-mode](https://github.com/jihongboo/dsh-apple-mode) — Xcode AI 集成：26 个 Xcode MCP 工具 + Apple 平台技能 ⭐1 · `dsh plugin add dsh-apple-mode`
+- [notes](https://github.com/zhaoolee/notes) — 开源版锤子便签：导出 DSH 会话为便签图片，支持 skill 调用 ⚠️ 无 license 文件 ⭐142
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) — DSH 会话费用统计（本会话/当日/历史 + 官方价格同步） ⭐31 · `dsh plugin add github:Han-1413141/dsh-cost-meter`
+- [dsh-user-experience](https://github.com/DietCokewithSugar/dsh-user-experience) — persona 驱动的 UX 走查：扫描 React/TS 源码找 UX 问题 ⭐18 · `dsh plugin add github:DietCokewithSugar/dsh-user-experience`
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — DeepSeek 账户余额与会话成本显示 ⭐13 · `dsh plugin add github:Ghost011118/dsh-balance-meter`
 
 <!-- nav:start -->
 ---

--- a/plugins/infrastructure-dev.md
+++ b/plugins/infrastructure-dev.md
@@ -4,14 +4,13 @@
 
 ## 插件管理 / 注册表 / 市场
 
-- [plugin-registry](https://github.com/dsh-external/plugin-registry) — 第三方本地插件系统：`dsh.plugin.json` 协议 + install/enable/disable + Web 面板（公开） ⭐40
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 插件管理控制台：浏览器面板管理官方 repository 插件 + 开发引导 ⭐40
 - [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) — 离线容忍的注册表：从 awesome 列表/GitHub topics/npm 发现并去重 DSH 插件 ⭐1
 - [dsh-hub](https://github.com/omdsh-dev/dsh-hub) — OMDSH 社区扩展 hub（基于官方 contracts） ⭐4 · `dsh plugin add @omdsh/dsh-hub`
 - [DSH-plugin-switch](https://github.com/Nexus-Aethra/DSH-plugin-switch) — 插件市场：浏览/搜索/安装 GitHub 项目，自动识别 plugin/skill ⭐2 · `dsh plugin add dsh-plugin-switch`
 - [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) — 把 DSH 快速接入 GitHub 插件生态的市场插件 ⭐6 · `dsh plugin add dsh-plugin-installer`
-- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) — 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） ⭐39 · `dsh plugin add @dsh-external/dsh-super-injector`
-- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) — 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop ⭐46
+- [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) — 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） ⭐48 · `dsh plugin add @dsh-external/dsh-super-injector`
+- [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) — 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop ⭐47
 
 ## 健康检查 / 诊断 / 审计
 
@@ -45,6 +44,8 @@
 - [dsh-multica-runtime](https://github.com/multica-ai/dsh-multica-runtime) — Multica 的 DSH runtime 桥接（stdio JSONL 协议） ⭐34 · `dsh plugin add @multica-ai/dsh-runtime`
 - [session-teleport](https://github.com/omdsh-dev/session-teleport) — PostgreSQL 单写者会话交接服务 ⭐2 · `dsh plugin add @mattheliu/session-teleport`
 - [session-persistence-rdb](https://github.com/morlay/session-persistence-rdb) — session 关系型数据库持久化 ⭐4 · `dsh plugin add @morlay/session-persistence-rdb`
+- [dsh-market](https://github.com/dsh-market/dsh-market) — DSH 可视化插件市场：浏览/搜索/一键安装 ⭐221 · `dsh plugin add github:dsh-market/dsh-market`
+- [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) — dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin 目录/安装/卸载 ⭐42 · `dsh plugin add github:Sanqi-normal/dsh-webui-market-plugin`
 
 <!-- nav:start -->
 ---

--- a/plugins/multimodal.md
+++ b/plugins/multimodal.md
@@ -2,9 +2,9 @@
 
 > **视觉与多模态**：图片问答、OCR、UI 还原、截图对比、VLM 桥接、电脑控制（GUI）。返回 [目录](../README.md#分类目录)
 
-- [modlens](https://github.com/liustack/modlens) — DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） ⭐1664 · `dsh plugin add @liustack/modlens`
-- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) — 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts ⭐401 · `dsh plugin add @dsh-external/dsh-vision-toolkit`
-- [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) — 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） ⭐882
+- [modlens](https://github.com/liustack/modlens) — DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） ⭐1736 · `dsh plugin add @liustack/modlens`
+- [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) — 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts ⭐409 · `dsh plugin add @dsh-external/dsh-vision-toolkit`
+- [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) — 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） ⭐887
 - [dsh-vision](https://github.com/william-jin-cmu/dsh-vision) — view_image 工具桥接任意 OpenAI 兼容 VLM（默认智谱免费档） ⭐23
 - [dsh-vision-LMstudio](https://github.com/TiankunDai/dsh-vision-LMstudio) — 通过 LM Studio 调用本地视觉模型 ⭐1
 - [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) — DeepSeek 大脑 + 自动识图（图片经 Qwen VLM 转文字后作答） ⭐8 · `dsh plugin add dsh-vision-proxy`
@@ -18,7 +18,7 @@
 - [dsh-mobile-control](https://github.com/PangYiMing/dsh-mobile-control) — 操控手机（ADB/iOS） ⭐2 · `dsh plugin add dsh-mobile-control`
 - [dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — 原生鸿蒙设备桥：hdc 截图-看图-装包-验证闭环调试 ⭐5 · `dsh plugin add dsh-hdc-bridge`
 - [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) — provider 无关的 AIGC HTTP 桥 + 自由画布 + ffmpeg 后处理 ⭐6 · `dsh plugin add @huanlin/dsh-plugin-aigc-canvas`
-- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) — 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） ⭐108 · `dsh plugin add dsh-vision-router`
+- [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) — 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） ⭐111 · `dsh plugin add dsh-vision-router`
 
 <!-- nav:start -->
 ---

--- a/plugins/notifications-channels.md
+++ b/plugins/notifications-channels.md
@@ -8,26 +8,25 @@
 - [dsh-telegram](https://github.com/ben7am1n/dsh-telegram) — Telegram 运行时适配器（per-chat 会话、allowlist 认证） ⭐1 · `dsh plugin add dsh-telegram`
 - [DSH-Telegram-Relay](https://github.com/congchuanling-dot/DSH-Telegram-Relay) — 通过 Telegram 远程对话并接收通知 ⭐5 · `dsh plugin add dsh-telegram-relay`
 - [dsh-chatnode-wechat](https://github.com/Jesse-njx/dsh-chatnode-wechat) — 通过 iLink 网关在微信里与 DSH agent 聊天/监控/审批 ⭐2 · `dsh plugin add @dsh-cowork/chatnode-wechat`
-- [dsh-lark](https://github.com/Roy-oss1/dsh-lark) — 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片 ⭐2 · `dsh plugin add @dsh-contrib/dsh-lark-channel`
+- [dsh-lark](https://github.com/Roy-oss1/dsh-lark) — 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片（已删除） ⭐2 · `dsh plugin add @dsh-contrib/dsh-lark-channel`
 - [dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) — 双向飞书控制器 ⭐7 · `dsh plugin add dsh-lark-bridge`
 - [dsh-onlyne](https://github.com/dbydd/dsh-onlyne) — IM 网关：从 dsh 会话收发 QQ/微信/飞书/Telegram 消息 ⭐2
 
 ## 通知
 
-- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) — 回合完成桌面通知，按结果分控 + 关键词过滤 ⭐45 · `dsh plugin add dsh-notification`
+- [dsh-notification](https://github.com/omdsh-dev/dsh-notification) — 回合完成桌面通知，按结果分控 + 关键词过滤 ⭐47 · `dsh plugin add dsh-notification`
 - [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) — Windows 通知（零依赖） ⭐3
 - [dsh-win-notify](https://github.com/MuziIsabel/dsh-win-notify) — Windows toast 通知（任务完成带声音） ⭐4 · `dsh plugin add dsh-win-notify`
 - [dsh-web-ui-notify](https://github.com/bill9109/dsh-web-ui-notify) — 桌面通知提醒 ⭐12 · `dsh plugin add @bill9109/dsh-web-ui-notify`
-- [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) — 会话完成等四种状态通知，支持浏览器提示 ⭐6 · `dsh plugin add @dingyi222666/dsh-session-notification`
+- [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) — 会话完成等四种状态通知，支持浏览器提示 ⭐7 · `dsh plugin add @dingyi222666/dsh-session-notification`
 
 ## 远程 / 集成 / 分享
 
 - [dsh-ssh](https://github.com/UynajGI/dsh-ssh) — SSH 远程执行（ProxyJump 链、SFTP 文件系统、PTY） ⭐4
 - [dsh-webhook-bridge](https://github.com/ben7am1n/dsh-webhook-bridge) — 通用 webhook 接收器：POST /hook/:channel 唤醒 per-channel agent ⭐1 · `dsh plugin add dsh-webhook-bridge`
-- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) — 从 Web GUI 一键在 VS Code 中打开工作区目录 ⭐41 · `dsh plugin add dsh-open-in-vscode`
-- [dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话 ⭐18 · `dsh plugin add @dsh-external/dsh-share`
+- [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) — 从 Web GUI 一键在 VS Code 中打开工作区目录 ⭐42 · `dsh plugin add dsh-open-in-vscode`
+- [dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话 ⭐19 · `dsh plugin add @dsh-external/dsh-share`
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — 分享任意段落的对话 ⭐1 · `dsh plugin add @bill9109/dsh-conversation-share`
-- [dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) — BitFun 与 DSH 的 ACP 交互对接 ⭐9 · `dsh plugin add dsh-acp-for-bitfun`
 
 <!-- nav:start -->
 ---

--- a/plugins/official-meta.md
+++ b/plugins/official-meta.md
@@ -4,28 +4,27 @@
 
 ## 官方
 
-- [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) — 官方核心仓库：「一切皆插件」，Cordis 驱动 ⭐107568
-- [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) — 官方 Agent 精选列表 ⭐5850
+- [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) — 官方核心仓库：「一切皆插件」，Cordis 驱动 ⭐109475
+- [deepseek-ai/awesome-deepseek-agent](https://github.com/deepseek-ai/awesome-deepseek-agent) — 官方 Agent 精选列表 ⭐5853
 - 官方插件开发文档：[架构](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/architecture.zh.md) · [Cordis 入门](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/cordis-primer.zh.md) · [第一个插件](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/develop/basic/index.zh.md) · [打包安装](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/develop/basic/publish.zh.md)
 
 > 官方**无内置插件市场**、无官方脚手架。分发渠道 = npm + `dsh plugin add` + `dsh-plugin` GitHub topic。
 
 ## 社区目录 / awesome 列表
 
-- [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) — 社区精选列表（105 插件 + 站点 + 徽章） ⭐2326
-- [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) — 「30 秒找到适合你的插件」，带场景说明 + 505 全量快照 ⭐132
-- [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) — DSH 生态精选：插件/工具/基础设施 ⭐454
-- [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) — 目录 + **每日兼容性雷达**（四维检查 + 运行实测） ⭐928
-- [Alex-Yanggg/awesome-DSH-plugin](https://github.com/Alex-Yanggg/awesome-DSH-plugin) — 覆盖生产力/扩展/调试/自定义开发的分类 catalog ⭐61
+- [awesome-dsh-plugin/awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) — 社区精选列表（105 插件 + 站点 + 徽章） ⭐2519
+- [bruc3van/awesome-dsh-plugin](https://github.com/bruc3van/awesome-dsh-plugin) — 「30 秒找到适合你的插件」，带场景说明 + 505 全量快照 ⭐139
+- [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) — DSH 生态精选：插件/工具/基础设施 ⭐465
+- [AdamPlatin123/awesome-dsh-plugins](https://github.com/AdamPlatin123/awesome-dsh-plugins) — 目录 + **每日兼容性雷达**（四维检查 + 运行实测） ⭐942
+- [Alex-Yanggg/awesome-DSH-plugin](https://github.com/Alex-Yanggg/awesome-DSH-plugin) — 覆盖生产力/扩展/调试/自定义开发的分类 catalog ⭐62
 
 ## 社区组织 / hub / registry（第三方，非官方）
 
 > `dsh-external` 是**第三方社区组织**，其仓库为公开/私有混合体，以下部分仓库公开性待核实。
 
-- [dsh-external/hub](https://github.com/dsh-external/hub) — 社区组织级索引/目录元仓库（⚠️ 私有，白名单可见）
-- [dsh-external/plugin-registry](https://github.com/dsh-external/plugin-registry) — 第三方插件系统：`dsh.plugin.json` 协议（公开） ⭐40
-- [dsh-external/marisa](https://github.com/dsh-external/marisa) — 「寄生式」外部插件管理器 `dshx`（⚠️ 私有，白名单可见）
-- [dsh-external/toybox](https://github.com/dsh-external/toybox) — 插件玩具箱：静态 `.dsh-plugin` 格式的技能/MCP 插件收藏（公开）
+- [dsh-external/hub](https://github.com/dsh-external/hub) — 社区组织级索引/目录元仓库（⚠️ 私有，白名单可见） （已删除）
+- [dsh-external/marisa](https://github.com/dsh-external/marisa) — 「寄生式」外部插件管理器 `dshx`（⚠️ 私有，白名单可见） （已删除）
+- [dsh-external/toybox](https://github.com/dsh-external/toybox) — 插件玩具箱：静态 `.dsh-plugin` 格式的技能/MCP 插件收藏（公开） （已删除）
 
 ## 第三方实现 / 商店
 
@@ -34,9 +33,9 @@
 
 ## 插件开发指南（社区）
 
-- [dsh-plugin-guide](https://github.com/dsh-external/dsh-plugin-guide) — DSH 插件开发指南：从零到精通 ⚠️ 公开性待核实
-- [dsh-cordis-rocks](https://github.com/dsh-external/dsh-cordis-rocks) — 16 章可逆 Cordis 配套教程 ⚠️ 公开性待核实
-- [dsh-cordis-examples](https://github.com/dsh-external/dsh-cordis-examples) — 最小原生 DSH/Cordis 扩展示例 ⚠️ 公开性待核实
+- [dsh-plugin-guide](https://github.com/dsh-external/dsh-plugin-guide) — DSH 插件开发指南：从零到精通 ⚠️ 已删除
+- [dsh-cordis-rocks](https://github.com/dsh-external/dsh-cordis-rocks) — 16 章可逆 Cordis 配套教程 ⚠️ 已删除
+- [dsh-cordis-examples](https://github.com/dsh-external/dsh-cordis-examples) — 最小原生 DSH/Cordis 扩展示例 ⚠️ 已删除
 - [plugin-template](https://github.com/omdsh-dev/plugin-template) — 插件模板仓库（基于 turtle-ui） ⭐5 · `dsh plugin add @your-scope/dsh-plugin-template`
 
 <!-- nav:start -->

--- a/plugins/skills.md
+++ b/plugins/skills.md
@@ -6,18 +6,19 @@
 - [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) — 把已有 Agent Skills（Claude/Codex/Cursor/Gemini 的 SKILL.md）带进 DSH，渐进式索引 + 按需加载 ⭐2 · `dsh plugin add @dsh-skillport/bundle`
 - [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) — 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索/安装/生命周期管理 ⭐2 · `dsh plugin add dsh-find-skill`
 - [dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) — 构建与测试 DSH 插件的 Agent 技能（脚手架到测试分层） ⭐7
-- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) — 五阶段「书→技能」长任务（抓取→解析→理解→生成→安装）+ 3 个人工关卡 ⭐3 · `dsh plugin add dsh-book2skill`
+- [dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) — 五阶段「书→技能」长任务（抓取→解析→理解→生成→安装）+ 3 个人工关卡 ⭐4 · `dsh plugin add dsh-book2skill`
 - [dsh-superpowers](https://github.com/codeAnqiang-ma/dsh-superpowers) — Superpowers（obra/superpowers）作为 DSH 插件：方法论技能 + 会话引导 ⭐3 · `dsh plugin add dsh-superpowers`
 - [dsh-plugin-code-review](https://github.com/YYTbit/dsh-plugin-code-review) — 结构化代码审查技能（YYTbit 系列） ⭐1 · `dsh plugin add dsh-plugin-code-review`
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) — 增量 diff 审查：checkpoint 队列 + Web 面板 + 审查意见注入 agent ⭐2 · `dsh plugin add @dsh-plugin/dsh-review-loop`
-- [dsh-skill-manager](https://github.com/bitterSmilezzz/dsh-skill-manager) — 在 Web 设置页管理（列出/禁用启用/编辑）skills ⭐1 · `dsh plugin add dsh-skill-manager`
+- [dsh-skill-manager](https://github.com/bitterSmilezzz/dsh-skill-manager) — 在 Web 设置页管理（列出/禁用启用/编辑）skills（已删除） ⭐1 · `dsh plugin add dsh-skill-manager`
 - [dsh-plugin-claude-bridge](https://github.com/YYTbit/dsh-plugin-claude-bridge) — 把 Claude Code 记忆/技能/配置桥接进 DSH ⭐5 · `dsh plugin add dsh-plugin-claude-bridge`
 - [dsh-plugin-codex-bridge](https://github.com/YYTbit/dsh-plugin-codex-bridge) — 把 Codex skills/config 桥接进 DSH ⭐2 · `dsh plugin add dsh-plugin-codex-bridge`
 - [dsh-plugin-opencode-bridge](https://github.com/YYTbit/dsh-plugin-opencode-bridge) — 把 OpenCode skills/config 桥接进 DSH ⭐3 · `dsh plugin add dsh-plugin-opencode-bridge`
 - [dsh-plugin-pi-bridge](https://github.com/YYTbit/dsh-plugin-pi-bridge) — 把 pi skills/config 桥接进 DSH ⭐2 · `dsh plugin add dsh-plugin-pi-bridge`
 - [Code2Skill](https://github.com/leechen298/Code2Skill) — 从现有代码生成 Function、MCP、Agent Skill 和离线测试包，并作为可安装的 DSH Bundle 分发 ⭐2 · `dsh plugin add github:leechen298/Code2Skill#v1.1.3`
-- [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） ⭐13 · `dsh plugin add github:dhicoc/dsh-reverse-skill`
-- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) — 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill ⭐84 · `dsh plugin add github:Nagi-ovo/dsh-find-plugins`
+- [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） ⭐12 · `dsh plugin add github:dhicoc/dsh-reverse-skill`
+- [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) — 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill ⭐89 · `dsh plugin add github:Nagi-ovo/dsh-find-plugins`
+- [forkprobe](https://github.com/Jayden-X-L/forkprobe) — 同一任务对比多个 skill 并选出最优 ⭐66 · `dsh plugin add github:Jayden-X-L/forkprobe`
 
 <!-- nav:start -->
 ---

--- a/plugins/tools.md
+++ b/plugins/tools.md
@@ -17,9 +17,9 @@
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) — 结构化 test_run：自动探测 vitest/jest/pytest/node:test 并解析失败摘要 ⭐2 · `dsh plugin add dsh-test-runner`
 - [dsh-security-scan](https://github.com/ben7am1n/dsh-security-scan) — 密钥/危险模式扫描（API key/token/私钥脱敏，零依赖） ⭐1 · `dsh plugin add dsh-security-scan`
 - [dsh-tool-search](https://github.com/vibeinging/dsh-tool-search) — 按 agent 的按需工具发现 + 渐进式 schema 披露 ⭐2 · `dsh plugin add @deepseek-ai/dsh-tool-search`
-- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) — 用 Monaco 编辑器创建/管理沙箱化自定义 JS 工具 ⭐23 · `dsh plugin add dsh-custom-tool`
+- [dsh-custom-tool](https://github.com/omdsh-dev/dsh-custom-tool) — 用 Monaco 编辑器创建/管理沙箱化自定义 JS 工具 ⭐24 · `dsh plugin add dsh-custom-tool`
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) — 自动识别并解码 Bash 输出编码（UTF-16LE/UTF-8/GBK），修中文乱码 ⭐7
-- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) — Codex 风格 `@file` 文件引用，输入框里直接搜索并引用工作区文件 ⭐187 · `dsh plugin add dsh-at-file`
+- [dsh-at-file](https://github.com/omdsh-dev/dsh-at-file) — Codex 风格 `@file` 文件引用，输入框里直接搜索并引用工作区文件 ⭐198 · `dsh plugin add dsh-at-file`
 - [dsh-wikilink](https://github.com/zhaoscsc/dsh-wikilink) — Obsidian 风格 `[[wikilink]]` 提及：模糊搜索笔记标题并附加内容 ⭐3 · `dsh plugin add dsh-wikilink`
 - [dsh-safe-delete](https://github.com/Qintsg/dsh-safe-delete) — 安全删除：移入回收站/暂存区而非永久删除，支持恢复 ⭐3
 - [dsh-bisect-debug](https://github.com/PangYiMing/dsh-bisect-debug) — 二分法定位 bug 根因（代码/边界/commit） ⭐1 · `dsh plugin add dsh-bisect-debug`
@@ -27,8 +27,8 @@
 - [dsh-data-agent](https://github.com/omdsh-dev/dsh-data-agent) — 让 AI 帮你连数据库、写 SQL ⭐25 · `dsh plugin add @deepseek-ai/dsh-data-agent`
 - [dsh-openapi](https://github.com/Degurechaff57/dsh-openapi) — Safe OpenAPI 3.x 发现与 API 调用工具 ⭐4 · `dsh plugin add dsh-openapi`
 - [dsh-plugin-interpreters](https://github.com/HuanLinOTO/dsh-plugin-interpreters) — 暴露 run_python / run_node 工具，可配置解释器路径 ⭐6 · `dsh plugin add @huanlin/dsh-plugin-interpreters`
-- [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) — doc_read/doc_write：以有界、单元格寻址方式读写 xlsx/pdf/docx/pptx/ipynb ⭐2
-- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) — 向模型暴露 MineRU 文档解析工具 ⭐18 · `dsh plugin add @huanlin/dsh-plugin-mineru`
+- [dsh-cowork](https://github.com/Jesse-njx/dsh-cowork) — doc_read/doc_write：以有界、单元格寻址方式读写 xlsx/pdf/docx/pptx/ipynb ⭐3
+- [dsh-plugin-mineru](https://github.com/HuanLinOTO/dsh-plugin-mineru) — 向模型暴露 MineRU 文档解析工具 ⭐20 · `dsh plugin add @huanlin/dsh-plugin-mineru`
 - [dsh-plugin-sleep](https://github.com/HuanLinOTO/dsh-plugin-sleep) — 暴露单个 `sleep` 工具，让模型按需暂停（支持取消） ⭐6 · `dsh plugin add @huanlin/dsh-plugin-sleep`
 - [dsh-port-guard](https://github.com/PangYiMing/dsh-port-guard) — 端口占用处置（复用/切换/精确 kill） ⭐1 · `dsh plugin add dsh-port-guard`
 - [dsh-scout](https://github.com/omdsh-dev/dsh-scout) — 只读环境探测：运行环境/版本/资源/端口/服务/硬件/工作区 ⭐2 · `dsh plugin add @deepseek-ai/dsh-tool-scout`

--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -5,7 +5,7 @@
 ## 皮肤 / 主题
 
 - [dsh-skins](https://github.com/Moeblack/dsh-skins) — Web UI 皮肤合集（含 harbor 夕港黄昏皮肤） ⭐3 · `dsh plugin add @dsh-external/dsh-web-skins`
-- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) — DSH Web 鲸鱼娘皮肤系列（深海女仆工坊） ⭐802
+- [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) — DSH Web 鲸鱼娘皮肤系列（深海女仆工坊） ⭐834
 - [dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) — QQ2006 复古皮肤 ⭐10
 - [dsh-miku-skin](https://github.com/stushansusu/dsh-miku-skin) — 初音未来主题（蓝紫渐变/毛玻璃/亮暗双主题） ⭐2 · `dsh plugin add @deepseek-ai/dsh-client-ui-skin-miku`
 - [dsh-deepcel](https://github.com/Small-tailqwq/dsh-deepcel) — 模仿 Excel 的皮肤 ⭐8
@@ -15,37 +15,37 @@
 - [dsh-web-background](https://github.com/BruceWu1126/dsh-web-background) — Web UI 背景自定义 ⭐2
 - [dsh-plugin-background](https://github.com/gameswu/dsh-plugin-background) — Web UI 壁纸自定义 ⭐8
 - [dsh-chat-width](https://github.com/chen-001/dsh-chat-width) — 调整回复宽度（终端宽度感知） ⭐3
-- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) — 换肤系统：21 套内置皮肤 + 一图生成整套配色 ⭐33
+- [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) — 换肤系统：21 套内置皮肤 + 一图生成整套配色 ⭐34
 
 ## 界面增强 / 面板
 
-- [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab ⭐988 · `dsh plugin add dsh-better-sidebar`
+- [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab ⭐1065 · `dsh plugin add dsh-better-sidebar`
 - [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) — 侧边栏集成文件浏览器、终端和 Git 审查 ⭐16 · `dsh plugin add @dsh-external/dsh-side-panel`
 - [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) — 「聚焦会话」精简视图，只关注最终产出结果 ⭐16 · `dsh plugin add @dingyi222666/dsh-focus-chat`
-- [ui-status-label](https://github.com/alingalingling/ui-status-label) — 把鲸鱼娘思考时的 "deep diving" 状态文案自定义 ⭐31 · `dsh plugin add dsh-ui-status-label`
-- [dsh-navbar](https://github.com/vlln/dsh-navbar) — 对话节点导航条，右缘节点串快速跳转 user 消息 ⭐22 · `dsh plugin add @dsh-external/dsh-navbar`
-- [dsh-task-status](https://github.com/vlln/dsh-task-status) — 后台任务状态条：对话页任务进度 + 实时输出 tail ⭐9 · `dsh plugin add @dsh-external/dsh-task-status`
+- [ui-status-label](https://github.com/alingalingling/ui-status-label) — 把鲸鱼娘思考时的 "deep diving" 状态文案自定义 ⭐32 · `dsh plugin add dsh-ui-status-label`
+- [dsh-navbar](https://github.com/vlln/dsh-navbar) — 对话节点导航条，右缘节点串快速跳转 user 消息 ⭐23 · `dsh plugin add @dsh-external/dsh-navbar`
+- [dsh-task-status](https://github.com/vlln/dsh-task-status) — 后台任务状态条：对话页任务进度 + 实时输出 tail ⭐10 · `dsh plugin add @dsh-external/dsh-task-status`
 - [dsh-web-archive](https://github.com/renat3u/dsh-web-archive) — 折叠对话中的 Think、Bash 等「无用消息」 ⭐7 · `dsh plugin add dsh-web-archive`
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) — 会话里程碑导航条：像 Git 提交图定位每条提问 ⭐14 · `dsh plugin add dsh-milestone`
 - [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) — 键盘优先的命令面板（command palette） ⭐5 · `dsh plugin add @dsh-external/dsh-spotlight`
 - [dsh-deeplink](https://github.com/qyw233/dsh-deeplink) — `?session=` / `?workspace=` 深链直达指定项目对话 ⭐1 · `dsh plugin add @dsh-community/dsh-deeplink`
-- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) — PiUI 风格 diff 查看器，替换 write/edit 的默认 DiffBlock ⭐11 · `dsh plugin add @dsh-external/dsh-diff-viewer`
+- [dsh-diff-viewer](https://github.com/lehhair/dsh-diff-viewer) — PiUI 风格 diff 查看器，替换 write/edit 的默认 DiffBlock ⭐12 · `dsh plugin add @dsh-external/dsh-diff-viewer`
 - [dsh-drag-and-drop](https://github.com/bill9109/dsh-drag-and-drop) — 跨平台文件拖拽与原始路径插入，无需复制文件 ⭐7 · `dsh plugin add @bill9109/dsh-drag-and-drop`
 - [ex-setting](https://github.com/omdsh-dev/ex-setting) — DSH 的设置扩展 ⭐2 · `dsh plugin add @deepseek-ai/dsh-ex-setting`
-- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) — 选中文字→批注→回车随消息发送，回复按批注逐条对照 ⭐48 · `dsh plugin add @omdsh-dev/dsh-annotation`
+- [dsh-annotation](https://github.com/omdsh-dev/dsh-annotation) — 选中文字→批注→回车随消息发送，回复按批注逐条对照 ⭐50 · `dsh plugin add @omdsh-dev/dsh-annotation`
 - [dsh-prompt-studio](https://github.com/Moeblack/dsh-prompt-studio) — 带实时预览的用户/内置 system prompt 分节编辑器 ⭐2 · `dsh plugin add dsh-prompt-studio`
 - [dsh-prompt-persona](https://github.com/Xilin3/dsh-prompt-persona) — 从设置页编辑系统提示词（deployment persona），带实时预览 ⭐4 · `dsh plugin add @xilin3/dsh-prompt-persona`
-- [dsh-model-selector](https://github.com/bitterSmilezzz/dsh-model-selector) — provider 分组折叠 + 名称搜索的模型选择器增强 ⭐1 · `dsh plugin add dsh-model-selector`
+- [dsh-model-selector](https://github.com/bitterSmilezzz/dsh-model-selector) — provider 分组折叠 + 名称搜索的模型选择器增强（已删除） ⭐1 · `dsh plugin add dsh-model-selector`
 - [dsh-local-filetree](https://github.com/Mongfayi/dsh-local-filetree) — 右侧详情列显示当前会话工作区文件树（懒加载、只读） ⭐1 · `dsh plugin add dsh-local-filetree`
 - [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) — 把滚出屏幕的折叠标签（Think/工具卡）钉在视口顶部 ⭐3 · `dsh plugin add dsh-sticky-disclosure`
 - [dsh-token-usage](https://github.com/hashdiana/dsh-token-usage) — 更美观的 Token 用量条：上下文占用/输入输出/缓存分解/首字延迟 ⭐2 · `dsh plugin add dsh-token-usage`
-- [dsh-model-config-sync](https://github.com/LiangYin233/dsh-model-config-sync) — 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 ⭐11 · `dsh plugin add dsh-model-config-sync`
-- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) — DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 ⭐2397 · `dsh plugin add dsh-web-ui`
+- [dsh-model-config-sync](https://github.com/LiangYin233/dsh-provider-model-configurator) — 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 ⭐11 · `dsh plugin add dsh-model-config-sync`
+- [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) — DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 ⭐2484 · `dsh plugin add dsh-web-ui`
 
 ## 生成式 UI / 组件
 
-- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) — 对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览 ⭐98 · `dsh plugin add @dsh-external/dsh-visualize`
-- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) — 助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景 ⭐91 · `dsh plugin add @omdsh-dev/dsh-genui`
+- [dsh-visualize](https://github.com/Nagi-ovo/dsh-visualize) — 对话内生成式 UI：模型把交互式 HTML 卡片直接画进会话流，带流式预览 ⭐100 · `dsh plugin add @dsh-external/dsh-visualize`
+- [dsh-genui](https://github.com/omdsh-dev/dsh-genui) — 助手回复内渲染交互式 UI 组件：布局、图表、表单、测验、mermaid、3D 场景 ⭐99 · `dsh plugin add @omdsh-dev/dsh-genui`
 - [web-components](https://github.com/omdsh-dev/web-components) — Web Components 支持 ⭐2 · `dsh plugin add @deepseek-ai/dsh-client-web-component`
 - [dsh-openpencil](https://github.com/ZSeven-W/dsh-openpencil) — OpenPencil 设计预览与编辑（Agent 操作真实设计画布） ⭐74 · `dsh plugin add @zseven-w/dsh-openpencil`
 

--- a/plugins/workflow-automation.md
+++ b/plugins/workflow-automation.md
@@ -3,16 +3,16 @@
 > **流程编排**：深度研究、定时任务/cron、条件唤醒、计划批注、审查闭环、模型路由、审批。返回 [目录](../README.md#分类目录)
 
 - [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) — 自适应深度研究编排器（基于官方 workflow 引擎） ⭐12 · `dsh plugin add @dsh-external/dsh-deep-research`
-- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) — 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） ⭐4 · `dsh plugin add @deepseek-ai/dsh-deepresearch`
+- [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) — 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） ⭐5 · `dsh plugin add @deepseek-ai/dsh-deepresearch`
 - [dsh-loop](https://github.com/vlln/dsh-loop) — 定时循环：`/loop` 命令 + loop 工具 + 活动状态条 ⭐3 · `dsh plugin add @dsh-external/dsh-loop`
 - [dsh-sentinel](https://github.com/fuhefei/dsh-sentinel) — 条件驱动唤醒：file/command/http/process/webhook 持久监视触发 agent ⭐7 · `dsh plugin add @dsh-external/dsh-sentinel`
-- [dsh-automation](https://github.com/titanwings/dsh-automation) — 定时任务：Coding 任务按计划在全新 Agent Session 中运行 ⭐37 · `dsh plugin add @dsh-external/dsh-automation`
+- [dsh-automation](https://github.com/titanwings/dsh-automation) — 定时任务：Coding 任务按计划在全新 Agent Session 中运行 ⭐39 · `dsh plugin add @dsh-external/dsh-automation`
 - [dsh-routines](https://github.com/Jesse-njx/dsh-routines) — cron 定时 Agent：按计划跑 prompt 并把摘要送到你所在处 ⭐1 · `dsh plugin add @dsh-routines/bundle`
 - [dsh-plannotator](https://github.com/titanwings/dsh-plannotator) — 计划批注：选中计划原文逐条批注并回送结构化反馈 ⭐5 · `dsh plugin add @dsh-external/dsh-plannotator`
 - [dsh-inspect](https://github.com/omdsh-dev/dsh-inspect) — 发现问题→修复→复查的对抗式闭环（基于官方 workflow 引擎） ⭐5 · `dsh plugin add @dsh-external/dsh-inspect`
-- [dsh-advisor](https://github.com/btspoony/dsh-advisor) — 副模型每轮被动审查并注入见解 ⭐9 · `dsh plugin add dsh-advisor`
-- [mstar-harness](https://github.com/btspoony/mstar-harness) — Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 ⭐45
-- [dsh-llm-fallbacks](https://github.com/btspoony/dsh-llm-fallbacks) — 基于角色的模型重试/备用策略 ⭐4 · `dsh plugin add dsh-llm-fallbacks`
+- [dsh-advisor](https://github.com/omdsh-dev/dsh-advisor) — 副模型每轮被动审查并注入见解 ⭐9 · `dsh plugin add dsh-advisor`
+- [mstar-harness](https://github.com/btspoony/mstar-harness) — Skill 驱动的 Harness/Loop 工程工作流 Agent 插件 ⭐46
+- [dsh-llm-fallbacks](https://github.com/omdsh-dev/dsh-llm-fallbacks) — 基于角色的模型重试/备用策略 ⭐4 · `dsh plugin add dsh-llm-fallbacks`
 - [dsh-polyglot](https://github.com/Jesse-njx/dsh-polyglot) — 模型切换器：任意 OpenAI 兼容端点 + 免费/低价 DeepSeek 预设 + 限流自动回退 ⭐1 · `dsh plugin add @dsh-polyglot/bundle`
 - [dsh-track](https://github.com/fakechris/dsh-track) — 嵌入式任务管理引擎：决策点协议、念头捕获墙、Linear 形 issue 存储 ⭐6 · `dsh plugin add @deepseek-ai/dsh-track`
 - [dsh-record-replay](https://github.com/humblebanana/dsh-record-replay) — 录制 macOS 桌面工作流演示并转成 agent 技能（orr_* 工具） ⭐7 · `dsh plugin add dsh-record-replay`
@@ -22,6 +22,7 @@
 - [dsh-tool-approval](https://github.com/ilharp/dsh-tool-approval) — 手动审批模式（Manual/Ask Mode） ⭐1 · `dsh plugin add dsh-tool-approval`
 - [dsh-tiered-approval](https://github.com/Elaina-real/dsh-tiered-approval) — 分层自动审查：静态规则 + LLM 审查 + 人工兜底 ⭐2 · `dsh plugin add dsh-tiered-approval`
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) — 事件流审计面板：观察事件类型/分发模式/计数，帮插件作者理解内部 ⭐1 · `dsh plugin add @dsh-external/dsh-event-auditor`
+- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) — 自动续传：网络中断后自动发「继续」恢复请求 ⭐15 · `dsh plugin add github:HsiangNianian/dsh-auto-continue`
 
 <!-- nav:start -->
 ---

--- a/scripts/probe-stars.mjs
+++ b/scripts/probe-stars.mjs
@@ -1,5 +1,6 @@
-// probe-stars.mjs — 直接探测目录里每个插件的实时 GitHub star，更新 data/plugins.json 与 plugins/*.md 的 ⭐。
-// 不再依赖上游 awesome-dsh-plugin 的 star 快照（上游已移除 stars.json / docs/plugins.json）。
+// probe-stars.mjs — 直接探测目录里每个插件的实时 GitHub 数据，更新 data/plugins.json 与 plugins/*.md。
+// 更新字段：stars、license、pushedAt、archived；并检测改名（301 重定向）与死仓库（404）。
+// 不再依赖上游 awesome-dsh-plugin 的 star 快照。
 // 用法：GITHUB_TOKEN=xxx node scripts/probe-stars.mjs
 import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -24,10 +25,11 @@ for (const f of CATEGORY_FILES) {
   while ((m = URL_RE.exec(content)) !== null) listed.add(m[1].toLowerCase())
 }
 
-// 2. 探测实时 star（分批并发）
-const H = { Authorization: `Bearer ${token}`, 'User-Agent': 'dsh-star-probe', Accept: 'application/vnd.github+json' }
-const starMap = new Map() // 小写 fullName -> stars
-let failed = 0
+// 2. 探测实时数据（分批并发）：stars + license + pushedAt + archived
+const H = { Authorization: `Bearer ${token}`, 'User-Agent': 'dsh-probe', Accept: 'application/vnd.github+json' }
+const repoMap = new Map() // 小写 fullName -> { stars, license, pushedAt, archived }
+const renamed = [] // { from, to }
+const dead = [] // fullName
 const fulls = [...listed]
 
 for (let i = 0; i < fulls.length; i += 20) {
@@ -35,22 +37,36 @@ for (let i = 0; i < fulls.length; i += 20) {
   await Promise.all(batch.map(async (full) => {
     try {
       const res = await fetch(`https://api.github.com/repos/${full}`, { headers: H })
-      if (!res.ok) { failed++; return }
+      if (res.status === 404) { dead.push(full); return }
+      if (!res.ok) return
       const repo = await res.json()
-      if (typeof repo.stargazers_count === 'number') starMap.set(full, repo.stargazers_count)
-    } catch { failed++ }
+      repoMap.set(full, {
+        stars: typeof repo.stargazers_count === 'number' ? repo.stargazers_count : null,
+        license: repo.license?.spdx_id ?? null,
+        pushedAt: repo.pushed_at ?? null,
+        archived: repo.archived ?? false,
+      })
+      // 改名检测：GitHub 对改名仓库返回重定向，full_name 是新名字
+      if (repo.full_name && repo.full_name.toLowerCase() !== full) {
+        renamed.push({ from: full, to: repo.full_name })
+      }
+    } catch { /* 网络/限流错误，忽略 */ }
   }))
 }
 
-// 3. 更新 data/plugins.json 里已有 fullName 的 star
+// 3. 更新 data/plugins.json：stars + license + pushedAt + archived
 const data = JSON.parse(readFileSync(DATA_PATH, 'utf8'))
 let dataUpdated = 0
 for (const p of data.plugins) {
   const key = p.fullName.toLowerCase()
-  if (starMap.has(key) && starMap.get(key) !== p.stars) {
-    p.stars = starMap.get(key)
-    dataUpdated++
-  }
+  const info = repoMap.get(key)
+  if (!info) continue
+  let changed = false
+  if (info.stars != null && info.stars !== p.stars) { p.stars = info.stars; changed = true }
+  if (info.license && info.license !== p.license) { p.license = info.license; changed = true }
+  if (info.pushedAt && info.pushedAt !== p.pushedAt) { p.pushedAt = info.pushedAt; changed = true }
+  if (p.archived === undefined || info.archived !== p.archived) { p.archived = info.archived; changed = true }
+  if (changed) dataUpdated++
 }
 if (dataUpdated > 0) {
   data.updatedAt = new Date().toISOString()
@@ -58,6 +74,7 @@ if (dataUpdated > 0) {
 }
 
 // 4. 更新 plugins/*.md 每个条目的 ⭐（保留已有 install 命令）
+const starMap = new Map([...repoMap].map(([k, v]) => [k, v.stars]))
 let mdUpdated = 0
 for (const f of CATEGORY_FILES) {
   const path = join(PLUGINS_DIR, f)
@@ -82,4 +99,12 @@ for (const f of CATEGORY_FILES) {
   writeFileSync(path, out.join('\n'))
 }
 
-console.log(`探测 ${listed.size} 个仓库，失败 ${failed} 个；data 更新 ${dataUpdated} 条，md 更新 ${mdUpdated} 条`)
+console.log(`探测 ${listed.size} 个仓库；data 更新 ${dataUpdated} 条，md 更新 ${mdUpdated} 条`)
+if (renamed.length) {
+  console.log(`\n⚠️ 改名仓库 ${renamed.length} 个：`)
+  for (const r of renamed) console.log(`  ${r.from} → ${r.to}`)
+}
+if (dead.length) {
+  console.log(`\n❌ 死仓库（404）${dead.length} 个：`)
+  for (const d of dead) console.log(`  ${d}`)
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,59 @@
+// validate.mjs — 校验目录数据质量（纯本地，不调网络）
+// 1. data/plugins.json 结构：plugins 数组 + 每条 fullName/url 非空
+// 2. 条目格式：是否匹配 `- [name](url) — 描述` 规范
+// 3. 重复仓库：同一 fullName 被多次收录
+// 用法：node scripts/validate.mjs
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url))
+const PLUGINS_DIR = join(ROOT, 'plugins')
+
+const taxonomy = JSON.parse(readFileSync(join(ROOT, 'data', 'taxonomy.json'), 'utf8'))
+const CATEGORY_FILES = taxonomy.categories.map((c) => c.file)
+
+const ENTRY_RE = /^-\s*\[[^\]]+\]\(https:\/\/github\.com\/[^)]+\)\s*—\s*.*$/
+
+const errors = []
+
+// 1. data/plugins.json 结构校验
+const data = JSON.parse(readFileSync(join(ROOT, 'data', 'plugins.json'), 'utf8'))
+if (!Array.isArray(data.plugins)) {
+  errors.push('data/plugins.json 缺少 plugins 数组')
+} else {
+  const missing = data.plugins.filter((p) => !p.fullName || !p.url)
+  if (missing.length) errors.push(`data 有 ${missing.length} 条缺 fullName/url`)
+}
+
+// 2. 目录条目格式 + 重复仓库校验
+const seen = new Map() // fullName(小写) -> 分类文件
+let total = 0
+for (const f of CATEGORY_FILES) {
+  const content = readFileSync(join(PLUGINS_DIR, f), 'utf8')
+  for (const line of content.split('\n')) {
+    if (!line.startsWith('- [')) continue
+    if (!ENTRY_RE.test(line)) {
+      errors.push(`格式错误 [${f}]: ${line.trim().slice(0, 70)}`)
+      continue
+    }
+    const m = line.match(/\(https:\/\/github\.com\/([^/]+\/[^)/?#]+)\)/)
+    if (m) {
+      const full = m[1].toLowerCase()
+      total++
+      if (seen.has(full)) {
+        errors.push(`重复仓库 [${f}]: ${full}（已见于 ${seen.get(full)}）`)
+      } else {
+        seen.set(full, f)
+      }
+    }
+  }
+}
+
+if (errors.length) {
+  console.error(`校验失败，共 ${errors.length} 个问题：`)
+  for (const e of errors) console.error('  ✗ ' + e)
+  process.exit(1)
+}
+
+console.log(`校验通过：data ${data.plugins?.length ?? 0} 条，目录 ${total} 条（唯一 ${seen.size}），无格式错误、无重复`)


### PR DESCRIPTION
## 四项优化 + 完善目录数据

### 1. probe-stars 补全元数据

探测时不再只取 star，顺带拿 `license` / `pushed_at` / `archived`：

- `license`：从恒 null → 补全 104 条
- `pushedAt`：从「收录日期近似」→ 实时 push 时间
- `archived`：新增字段，可标记归档插件

### 2. 改名 / 死仓库修正

probe-stars 新增改名（301 重定向）与死仓库（404）检测，本次修正：

- **改名 9 个**：更新 URL 到新仓库（如 dsh-sidechain → omdsh-dev、dsh-a2a → dpskh）
- **死仓库 16 个**：标记「已删除」（多为 dsh-external 私有仓库、作者已删的仓库）
- **删除 3 个合并/重复条目**（oh-dsh-desktop 已合并、plugin-registry 重复）

### 3. validate 加强

新增 `scripts/validate.mjs`（替换 validate.yml 里的弱校验），校验：

- data 结构（plugins 数组 + fullName/url 非空）
- 条目格式（`- [name](url) — 描述` 规范）
- **重复仓库检测**

首次运行就抓到 3 个重复收录（dsh-webfetch、dsh-acp-for-bitfun、dsh-openpencil），已修复。

### 4. 对账候选补录

从 246 个「数据里有但目录没收录」的候选中，审查并补录 **10 个高星插件**：

| 插件 | ⭐ | 分类 |
|---|---|---|
| dsh-market | 221 | infrastructure-dev |
| notes (zhaoolee) | 142 | fun-other |
| argo (taxueseek) | 77 | browser-search |
| forkprobe | 66 | skills |
| dsh-webui-market-plugin | 42 | infrastructure-dev |
| dsh-cost-meter | 31 | fun-other |
| deepseek-harness-tui | 25 | desktop-tui-mobile |
| dsh-user-experience | 18 | fun-other |
| dsh-auto-continue | 15 | workflow-automation |
| dsh-balance-meter | 13 | fun-other |

## 结果

目录 295 → **305 条**，校验通过（无格式错误、无重复）。
