### PR TITLE
Add dsh-homepage-skin (ui-themes)

### DIFF
--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -53,3 +53,4 @@
 ---
 ← [上一类: 🔌 MCP 接入](mcp.md) · [返回目录](../README.md) · [下一类: 🖥️ 桌面端 / TUI / 移动端](desktop-tui-mobile.md) →
 <!-- nav:end -->
+- [dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) — 给 dsh web 铺上 DeepSeek Harness 首页同款背景：WebGL 流体、点线网格与数字鲸鱼，深浅双主题。


### PR DESCRIPTION
Adds dsh-homepage-skin to ui-themes.

Installable via `dsh plugin --profile web add github:yushi-xxh/dsh-homepage-skin` (dsh.bundle manifest + cordis.patch.yml). Real working code, dsh-plugin topic set.