### PR TITLE
Add suhui: memory distillation skill from chat history

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,16 +20,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/probe-stars.mjs
 
-      - name: Regenerate README, INDEX and web data
+      - name: Regenerate README and INDEX
         run: |
           node scripts/gen-index.mjs
           node scripts/gen-readme.mjs
-          node scripts/gen-web-data.mjs
 
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugins/ INDEX.md README.md README.zh.md web/data.js
+          git add data/plugins.json plugins/ INDEX.md README.md README.zh.md
           git commit -m "chore: sync live stars from GitHub" || exit 0
           git push

--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -14,6 +14,8 @@
 - [dsh-kb-sieve](https://github.com/omdsh-dev/dsh-kb-sieve) — 从 md/txt/docx/pdf 构建可审计知识库包（SQLite FTS5） ⭐2 · `dsh plugin add @dsh-external/dsh-kb-sieve`
 - [dsh-llm-wiki](https://github.com/detpecca/dsh-llm-wiki) — 从 agent 管理 LLM-Wiki 知识库（wiki_search/read/stats/ingest 等） ⭐4 · `dsh plugin add @detpecca/dsh-llm-wiki`
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格）沉淀自会话轨迹，带审查门禁与技能热加载 ⭐14 · `dsh plugin add dsh-continual-evolve`
+- [suhui](https://github.com/stargazer-2026/suhui-memory-skill) — 从聊天记录蒸馏人格与记忆为可对话 skill（原文级记忆 + 世界树联想）· 安装: `git clone https://github.com/stargazer-2026/suhui-memory-skill ~/.dsh/skills/suhui`（skill-filesystem 官方路径，dsh 自动解析 SKILL.md）
+
 - [dsh-meow-memory](https://github.com/Phant0Meow/dsh-meow-memory) — 跨会话项目记忆：SQLite 分层存储 + 关键词/语义检索，逐消息命中注入与窗口期整理 ⭐36 · `dsh plugin add github:Phant0Meow/dsh-meow-memory`
 
 ## 上下文审计 / 压缩 / 蒸馏


### PR DESCRIPTION
## What

Add suhui to the Context/Memory → 记忆/知识 category.

suhui is a memory-distillation skill: it turns exported chat history (WeChat/QQ/Telegram/Douyin/iMessage/Twitter archive/plain text) into a living memory world — persona distillation, verbatim-level memory with three-channel retrieval (vector + BM25 + world-tree labels), competitive interference forgetting, continuous presence (state snapshots, sleep/wake cycle), pro/flash dual builds.

## Why it fits

- SKILL.md skill bundle; installable via `dsh plugin add github:stargazer-2026/suhui` or `~/.dsh/skills/suhui/` (DSH support documented in README)
- Memory distillation is exactly the 上下文蒸馏 boundary of this category
- MIT, open source; repo contains only synthetic placeholder data (privacy-first)