### PR TITLE
Add JohnXu22786's 36 dsh plugins (complete set)

### DIFF
--- a/plugins/browser-search.md
+++ b/plugins/browser-search.md
@@ -4,6 +4,7 @@
 
 ## 浏览器操控
 
+- [browser-automation](https://github.com/JohnXu22786/browser-automation) — Web Bridge 浏览器自动化 MCP：真实浏览器导航/点击/填表/截图/JS 执行
 - [dsh-browser](https://github.com/Lum1104/dsh-browser) — Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器（无需视觉能力） ⭐396
 - [dsh-browser-control](https://github.com/PangYiMing/dsh-browser-control) — CDP/Playwright 操控浏览器 ⭐1 · `dsh plugin add dsh-browser-control`
 - [ego-browser](https://github.com/Fisfzy/ego-browser) — 把 ego-lite（给 AI Agent 的 Chromium）接入 DSH，13 个结构化 ego_* 工具 ⭐31
@@ -16,6 +17,7 @@
 
 ## 搜索 / 抓取
 
+- [semantic-search](https://github.com/JohnXu22786/semantic-search) — 代码/仓库本地语义搜索：嵌入索引 + 相关片段检索
 - [dsh-web-search-firecrawl](https://github.com/yangzhe1003/dsh-web-search-firecrawl) — Firecrawl 搜索提供方接入内置 web_search ⭐2 · `dsh plugin add @yangzhe1003/dsh-web-search-firecrawl`
 - [dsh-web-search-tavily](https://github.com/crayonlu/dsh-web-search-tavily) — Tavily 搜索提供方（免 DeepSeek key） ⭐3
 - [dsh-tavily-search](https://github.com/zhouzhencheng07/dsh-tavily-search) — 免 key Tavily 搜索工具 ⭐4 · `dsh plugin add dsh-tavily-search`

--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -4,6 +4,8 @@
 
 ## 记忆 / 知识
 
+- [docindex](https://github.com/JohnXu22786/docindex) — 工作区本地语义索引：增量构建 + 片段查询
+- [memory-standard](https://github.com/JohnXu22786/memory-standard) — Memory Standard 协议（mm）分层记忆：感知/工作/长期库
 - [dsh-memory-evolve](https://github.com/csyangwen/dsh-memory-evolve) — 跨会话长期记忆 + 后台自我进化（五轨记忆/git 分支感知/技能进化） ⭐225
 - [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) — 模型驱动上下文压缩（ACP）：模型决定何时压缩（移植自 billion-context-pi） ⭐35
 - [dsh-memory](https://github.com/Jesse-njx/dsh-memory) — 基于无损会话日志的引用式记忆（事实带 sessionId/eventRange 引用） ⭐2 · `dsh plugin add @dsh-memory/bundle`
@@ -18,6 +20,9 @@
 
 ## 上下文审计 / 压缩 / 蒸馏
 
+- [context-pruner](https://github.com/JohnXu22786/context-pruner) — 会话上下文分诊：token 预算裁剪、总结、压缩
+- [session-export](https://github.com/JohnXu22786/session-export) — 会话导出、脱敏与合规归档 bundle
+- [session-titler](https://github.com/JohnXu22786/session-titler) — 会话标题二次生成：两阶段摘要（草稿 + 精修）
 - [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) — 上下文注入审计：统计指令链/技能目录/工具 schema 的 token 成本，检测重复冲突 ⭐18 · `dsh plugin add dsh-context-doctor`
 - [context-vista](https://github.com/GooodWei/context-vista) — `/context` 命令 + 环形图实时展示上下文 token 用量与费用 ⭐12 · `dsh plugin add context-vista`
 - [distill](https://github.com/LoserFox/distill) — 自动对话蒸馏：后台 subagent 反省 + 技能 create/update ⭐21 · `dsh plugin add @loserfox/distill`

--- a/plugins/fun-other.md
+++ b/plugins/fun-other.md
@@ -4,6 +4,8 @@
 
 ## 游戏
 
+- [bookkeeping](https://github.com/JohnXu22786/bookkeeping) — 会话式记账：分类账本、流水记录与消费统计
+- [market-watch](https://github.com/JohnXu22786/market-watch) — 金融市场监控：行情聚合、涨跌提醒
 - [dsh-gomoku](https://github.com/omdsh-dev/dsh-gomoku) — 与 AI 下五子棋，也可双 AI 对弈比棋力 ⭐14 · `dsh plugin add @deepseek-ai/dsh-gomoku`
 - [dsh-minigames](https://github.com/lhh010/dsh-minigames) — 右侧 18 款离线小游戏面板（恐龙跳一跳/俄罗斯方块/扫雷/2048…） ⭐26 · `dsh plugin add @dsh-external/dsh-minigames`
 - [dsh-auto-chess](https://github.com/omdsh-dev/dsh-auto-chess) — 自走棋：人机对战或双 AI 对弈 ⭐3 · `dsh plugin add @deepseek-ai/dsh-auto-chess`

--- a/plugins/infrastructure-dev.md
+++ b/plugins/infrastructure-dev.md
@@ -4,6 +4,9 @@
 
 ## 插件管理 / 注册表 / 市场
 
+- [ci-runner](https://github.com/JohnXu22786/ci-runner) — 触发 GitHub Actions 与本地测试流水线，流式回传日志，失败时把日志尾部交给 agent 诊断
+- [dsh-web-submit](https://github.com/JohnXu22786/dsh-web-submit) — 让 CLI 任务跑在已运行的 dsh Web 进程内：Web UI 实时可见（POST /x/headless + SSE）
+- [headless-json](https://github.com/JohnXu22786/headless-json) — headless 模式的结构化机器可读输出（JSON + 稳定退出码），CI 友好
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 插件管理控制台：浏览器面板管理官方 repository 插件 + 开发引导 ⭐56
 - [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) — 离线容忍的注册表：从 awesome 列表/GitHub topics/npm 发现并去重 DSH 插件 ⭐1
 - [dsh-hub](https://github.com/omdsh-dev/dsh-hub) — OMDSH 社区扩展 hub（基于官方 contracts） ⭐4 · `dsh plugin add @omdsh/dsh-hub`
@@ -14,6 +17,7 @@
 
 ## 健康检查 / 诊断 / 审计
 
+- [auditrail](https://github.com/JohnXu22786/auditrail) — 安全审计与会话取证：完整工具调用链录制（谁/何时/动过哪些文件/脱敏回放）
 - [dsh-plugin-check](https://github.com/omdsh-dev/dsh-plugin-check) — 插件健康检查：扫描清单协议/patch 格式/构建陷阱/hub 状态 ⭐27 · `dsh plugin add @deepseek-ai/dsh-plugin-check`
 - [dsh-plugin-doctor](https://github.com/lin-cheng-lab/dsh-plugin-doctor) — 插件体检：安装前检查 peer 版本兼容性 ⭐1 · `dsh plugin add dsh-plugin-doctor`
 - [dsh-doctor](https://github.com/asdf17128/dsh-doctor) — profile 健康检查：找 patch 静默破坏的配置/死 patch/工具名冲突 ⭐1
@@ -24,6 +28,7 @@
 
 ## 运行时 / 沙箱 / 遥测 / hook
 
+- [hooks-adapter](https://github.com/JohnXu22786/hooks-adapter) — 通用 hooks 兼容层：把各家 harness 的 hook 语义统一映射到 dsh
 - [dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — 自进化：agent 会话内给自己热挂载/卸载持久化插件 ⭐10 · `dsh plugin add @dsh-external/dsh-evolve`
 - [dsh-trace](https://github.com/vibeinging/dsh-trace) — 遥测后端：导出 turns/model steps/tool calls 到 yiTrace ⭐2 · `dsh plugin add @deepseek-ai/dsh-trace`
 - [fabric](https://github.com/omdsh-dev/fabric) — 类似 MC Fabric 的 hook 处理器 ⭐15 · `dsh plugin add cordis-fabric-bundle`

--- a/plugins/mcp.md
+++ b/plugins/mcp.md
@@ -2,6 +2,8 @@
 
 > **MCP 协议相关**：MCP 服务器管理、MCP 代理、webfetch、OAuth MCP 客户端、视觉 MCP server。返回 [目录](../README.md#分类目录)
 
+- [docs-retriever](https://github.com/JohnXu22786/docs-retriever) — doctrove：版本化库文档检索 MCP server（零运行时依赖）
+- [github-mcp](https://github.com/JohnXu22786/github-mcp) — repogate：GitHub 开发者工作台 MCP（仓库/issue/PR/代码审查）
 - [dsh-mcp-proxy](https://github.com/ben7am1n/dsh-mcp-proxy) — 省上下文的惰性 MCP 访问 ⭐1 · `dsh plugin add dsh-mcp-proxy`
 - [deepseek-harness-plugin-mcp](https://github.com/bobleer/deepseek-harness-plugin-mcp) — 让任意 agent 发现/安装/运行 DSH 插件的 MCP server ⭐3 · `dsh plugin add deepseek-harness-plugin-mcp`
 - [dsh-webfetch](https://github.com/withlovehub/dsh-webfetch) — 零依赖 webfetch MCP server（干净文本/markdown/HTML/JSON，robots.txt 合规，SSRF 防护） ⭐3

--- a/plugins/multimodal.md
+++ b/plugins/multimodal.md
@@ -2,6 +2,7 @@
 
 > **视觉与多模态**：图片问答、OCR、UI 还原、截图对比、VLM 桥接、电脑控制（GUI）。返回 [目录](../README.md#分类目录)
 
+- [computer-control](https://github.com/JohnXu22786/computer-control) — 桌面控制：截屏/指针/键盘/窗口操作（GUI 自动化）
 - [modlens](https://github.com/liustack/modlens) — DSH 首个视觉插件：粘贴图片返回结构化 JSON 证据（OCR/布局/语义） ⭐3531 · `dsh plugin add @liustack/modlens`
 - [dsh-vision-toolkit](https://github.com/Anionex/dsh-vision-toolkit) — 纯文本模型的视觉工具箱：图片问答、长截图 OCR、UI 还原、定位、像素对比、Artifacts ⭐809 · `dsh plugin add @dsh-external/dsh-vision-toolkit`
 - [agent-vision-toolkit](https://github.com/Anionex/agent-vision-toolkit) — 同上，agent 通用视觉工具箱与技能（多图理解/GUI 自动化） ⭐1096

--- a/plugins/notifications-channels.md
+++ b/plugins/notifications-channels.md
@@ -14,6 +14,7 @@
 
 ## 通知
 
+- [rss-digest](https://github.com/JohnXu22786/rss-digest) — RSS/Atom 订阅摘要：定时拉取 + LLM 摘要投递
 - [dsh-notification](https://github.com/omdsh-dev/dsh-notification) — 回合完成桌面通知，按结果分控 + 关键词过滤 ⭐71 · `dsh plugin add dsh-notification`
 - [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) — Windows 通知（零依赖） ⭐5
 - [dsh-win-notify](https://github.com/MuziIsabel/dsh-win-notify) — Windows toast 通知（任务完成带声音） ⭐4 · `dsh plugin add dsh-win-notify`

--- a/plugins/skills.md
+++ b/plugins/skills.md
@@ -2,6 +2,10 @@
 
 > **SKILL.md 技能包**：工程纪律、代码审查、技能迁移（Claude/Codex/Cursor/Gemini）、书转技能、插件开发技能。返回 [目录](../README.md#分类目录)
 
+- [adversarial-review](https://github.com/JohnXu22786/adversarial-review) — 对抗式多视角代码审查：多透镜并行攻击式审查 + 静态哨兵 + 跨视角去重
+- [docgen](https://github.com/JohnXu22786/docgen) — 文档工坊技能包（纯提示词）：README/PR 描述/CHANGELOG 生成
+- [skill-framework](https://github.com/JohnXu22786/skill-framework) — Praxis：工程方法论技能库（SKILL.md 集合：计划/审查/复盘）
+- [spec-driven](https://github.com/JohnXu22786/spec-driven) — keel 龙骨：规格驱动开发纪律技能包（先立规格、验证假设、防过度工程）
 - [dsh-review-skills](https://github.com/ben7am1n/dsh-review-skills) — 工程纪律技能包：code-review/simplify/plan-then-execute/test-first/resolve-conflict ⭐2 · `dsh plugin add dsh-review-skills`
 - [dsh-skillport](https://github.com/Jesse-njx/dsh-skillport) — 把已有 Agent Skills（Claude/Codex/Cursor/Gemini 的 SKILL.md）带进 DSH，渐进式索引 + 按需加载 ⭐3 · `dsh plugin add @dsh-skillport/bundle`
 - [dsh-find-skill](https://github.com/Moximxxx/dsh-find-skill) — 桥接 vercel-labs/skills 生态：LLM 驱动技能搜索/安装/生命周期管理 ⭐3 · `dsh plugin add dsh-find-skill`

--- a/plugins/tools.md
+++ b/plugins/tools.md
@@ -2,6 +2,16 @@
 
 > 面向模型的**确定性工具**：计算、编码、JSON/CSV/正则、git、测试运行、安全删除、payload 捕获等。返回 [目录](../README.md#分类目录)
 
+- [apply-patch](https://github.com/JohnXu22786/apply-patch) — 把 git 格式 unified diff 安全应用到真实文件（冲突检测/回滚提示）
+- [codegraph](https://github.com/JohnXu22786/codegraph) — 代码知识图谱索引：符号/调用关系/多语言间图查询
+- [command-scout](https://github.com/JohnXu22786/command-scout) — 扫描项目声明的构建命令（Makefile/npm/justfile/deno 等）
+- [db-connector](https://github.com/JohnXu22786/db-connector) — 数据库连接器 bundle：SQLite/PostgreSQL 等结构化查询工具
+- [model-catalog](https://github.com/JohnXu22786/model-catalog) — 模型目录自动发现：拉取模型列表/定价/能力元数据
+- [net-debug](https://github.com/JohnXu22786/net-debug) — HTTP 网络调试工具集：请求构造、SSRF 检测、响应分析
+- [safety-net](https://github.com/JohnXu22786/safety-net) — 破坏性命令拦截闸门：rm -rf / git reset --hard / push --force 等先确认后执行
+- [secret-guard](https://github.com/JohnXu22786/secret-guard) — 密钥防护：禁止 agent 读写敏感文件、输出脱敏
+- [subtitle-studio](https://github.com/JohnXu22786/subtitle-studio) — 多语言字幕翻译工作流：SRT/VTT 解析、逐句 LLM 翻译、双语合并
+- [worktree-mgr](https://github.com/JohnXu22786/worktree-mgr) — 为任务自动创建隔离 git 工作区，管理创建/同步/收尾全生命周期
 - [dsh-toolkit](https://github.com/omdsh-dev/dsh-toolkit) — 零依赖工具十件套（time/encoding/json/calculator/csv/regex/markdown/diff/stat/schema）一键安装 ⭐25 · `dsh plugin add @deepseek-ai/dsh-toolkit`
 - [dsh-tool-calculator](https://github.com/omdsh-dev/dsh-tool-calculator) — 安全的数学表达式求值器，零依赖递归下降解析器 ⭐7 · `dsh plugin add @deepseek-ai/dsh-tool-calculator`
 - [dsh-tool-csv](https://github.com/omdsh-dev/dsh-tool-csv) — CSV 解析/查询/统计/转换（RFC 4180） ⭐4 · `dsh plugin add @deepseek-ai/dsh-tool-csv`

--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -20,6 +20,7 @@
 
 ## 界面增强 / 面板
 
+- [snippet-expander](https://github.com/JohnXu22786/snippet-expander) — Steno：输入框 #tag 简写自动展开（宏/提示词模板）
 - [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab ⭐2667 · `dsh plugin add dsh-better-sidebar`
 - [dsh-side-panel](https://github.com/ccq1/dsh-side-panel) — 侧边栏集成文件浏览器、终端和 Git 审查 ⭐16 · `dsh plugin add @dsh-external/dsh-side-panel`
 - [dsh-focus-chat](https://github.com/dingyi222666/dsh-focus-chat) — 「聚焦会话」精简视图，只关注最终产出结果 ⭐21 · `dsh plugin add @dingyi222666/dsh-focus-chat`

--- a/plugins/workflow-automation.md
+++ b/plugins/workflow-automation.md
@@ -2,6 +2,9 @@
 
 > **流程编排**：深度研究、定时任务/cron、条件唤醒、计划批注、审查闭环、模型路由、审批。返回 [目录](../README.md#分类目录)
 
+- [calendar](https://github.com/JohnXu22786/calendar) — CalDAV + iCalendar + RRULE 日历集成 bundle，含农历/节假日（中文场景）
+- [file-planning](https://github.com/JohnXu22786/file-planning) — trailmap 轨迹地图：磁盘持久化的执行规划（里程碑/步骤状态机/审计事件）
+- [review-gate](https://github.com/JohnXu22786/review-gate) — 把代码审查变成结构化闸门：通过/拦截/打回，全流程留痕
 - [dsh-deep-research](https://github.com/omdsh-dev/dsh-deep-research) — 自适应深度研究编排器（基于官方 workflow 引擎） ⭐18 · `dsh plugin add @dsh-external/dsh-deep-research`
 - [dsh-deepresearch](https://github.com/havingautism/dsh-deepresearch) — 证据优先的独立研究工作流（持久状态 + 独立 Web 视图） ⭐10 · `dsh plugin add @deepseek-ai/dsh-deepresearch`
 - [dsh-loop](https://github.com/vlln/dsh-loop) — 定时循环：`/loop` 命令 + loop 工具 + 活动状态条 ⭐5 · `dsh plugin add @dsh-external/dsh-loop`


### PR DESCRIPTION
## 新增插件清单（36 个，完整真实集合）

来自 [JohnXu22786](https://github.com/JohnXu22786) 的 36 个 DSH 插件（仓库均为 public、带 `dsh-plugin` topic、MIT 协议、中英双语 README），按 [docs/taxonomy.md](https://github.com/kejixiaoliang/awesome-dsh-plugins/blob/main/docs/taxonomy.md) 归入 11 个分类文件。本次为上一版（26 个）的完整重建：已剔除 7 个无效条目（对应仓库不存在），并补齐 8 月 17 日之后新增的 17 个插件，全部条目链接可访问。

**上下文 / 记忆**（context-memory.md）：memory-standard / context-pruner / session-titler / session-export / docindex

**工具类**（tools.md）：safety-net / command-scout / secret-guard / worktree-mgr / codegraph / model-catalog / apply-patch / db-connector / net-debug / subtitle-studio

**技能类**（skills.md）：skill-framework / spec-driven / adversarial-review / docgen

**MCP 接入**（mcp.md）：github-mcp / docs-retriever

**浏览器 / 搜索**（browser-search.md）：browser-automation / semantic-search

**基础设施 / 开发工具**（infrastructure-dev.md）：hooks-adapter / ci-runner / headless-json / auditrail / dsh-web-submit

**工作流 / 自动化**（workflow-automation.md）：file-planning / review-gate / calendar

**多模态 / 视觉**（multimodal.md）：computer-control

**通知 / 渠道**（notifications-channels.md）：rss-digest

**Web UI / 皮肤 / 主题**（ui-themes.md）：snippet-expander

**娱乐 / 其他**（fun-other.md）：bookkeeping / market-watch

所有仓库均可作为本地/远程插件安装（含 cordis.patch.yml 与可运行代码），README 中英双语。