### PR TITLE
Add dph-fleet: decentralized multi-device fleet plugin

### DIFF
--- a/plugins/agent-orchestration.md
+++ b/plugins/agent-orchestration.md
@@ -14,8 +14,10 @@
 - [dsh-a2a](https://github.com/dpskh/dsh-a2a) — Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 ⭐4
 - [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) — 子代理树可视化 ⚠️ dsh-external，已删除
 - [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) — 团队协作（cordis）⚠️ dsh-external，已删除
+- [dph-fleet](https://github.com/polaris-smart/dph-fleet) — 去中心化多设备舰队：mDNS 同网发现 + 密钥配对 + SSH 跨网直连指挥，任何设备可派单/接单（零 npm 依赖）· 安装包见 Releases（`dsh plugin add dph-fleet-<version>.tgz`）
 
 <!-- nav:start -->
 ---
 ← [上一类: 🖥️ 桌面端 / TUI / 移动端](desktop-tui-mobile.md) · [返回目录](../README.md) · [下一类: 🧠 上下文 / 记忆](context-memory.md) →
 <!-- nav:end -->
+


### PR DESCRIPTION
新增条目到 agent-orchestration 分类：

**dph-fleet**（polaris-smart/dph-fleet）— 去中心化多设备舰队插件：

- mDNS 同网自动发现 + WiFi 式密钥配对
- SSH 跨网直连执行（配对后一句话指挥远端设备干活）
- 模块开关（mdns / ssh / both），零 npm 依赖，84 条测试
- 声明 dsh.bundle，可通过 dsh plugin add 安装（安装包见仓库 Releases）；已挂 dsh-plugin topic

多设备编排在 dsh 生态目前是空白方向（跨机调度类插件零占位），符合本分类"多 Agent 与编排"的边界（跨设备的 agent 协作与任务分发）。
