### PR TITLE
新增 dsh-im 多平台 IM 机器人插件

### DIFF
--- a/plugins/notifications-channels.md
+++ b/plugins/notifications-channels.md
@@ -11,6 +11,7 @@
 - [dsh-lark](https://github.com/Roy-oss1/dsh-lark) — 飞书 IM bot 通道：聊天驱动 agent、审批回传卡片（已删除） ⭐2 · `dsh plugin add @dsh-contrib/dsh-lark-channel`
 - [dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) — 双向飞书控制器 ⭐7 · `dsh plugin add dsh-lark-bridge`
 - [dsh-onlyne](https://github.com/dbydd/dsh-onlyne) — IM 网关：从 dsh 会话收发 QQ/微信/飞书/Telegram 消息 ⭐2
+- [dsh-im](https://github.com/xmanrui/dsh-im) — 一个设置入口接入飞书、微信、钉钉、企业微信、QQ、Slack、Telegram、Discord 和 WhatsApp 机器人，支持扫码、App Manifest 或凭据绑定 · `dsh plugin add @xmanrui/dsh-im`
 
 ## 通知
 


### PR DESCRIPTION
- [x] 插件未在目录中重复收录（先在对应分类文件里搜一下）
- [x] 分类符合 [docs/taxonomy.md](docs/taxonomy.md) 的边界
- [x] 描述一句话说清「解决什么问题」
- [x] 链接为公开 GitHub 仓库

### 变更类型
- [x] 新增插件
- [ ] 修正分类 / 描述
- [ ] 删除已失效条目
- [ ] 其他

### 说明

在「通知 / 渠道 / 远程 → IM 机器人 / 渠道」分类新增 `dsh-im`。该插件通过一个设置入口将 DeepSeek Harness 接入飞书、微信、钉钉、企业微信、QQ、Slack、Telegram、Discord 和 WhatsApp，支持扫码、App Manifest 或机器人凭据绑定。

验证：`node scripts/validate.mjs` 通过，无格式错误和重复条目。