### PR TITLE
收录 PerryLink 的 28 个插件(9 个分类)

### DIFF
--- a/plugins/agent-orchestration.md
+++ b/plugins/agent-orchestration.md
@@ -12,6 +12,7 @@
 - [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) — 可配置子代理 profiles + 实时工具调用/token 显示 + 子会话跳转 ⭐11 · `dsh plugin add @huanlin/dsh-plugin-yet-another-subagent`
 - [dsh-a2a](https://github.com/dpskh/dsh-a2a) — Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 ⭐5
 - [dph-fleet](https://github.com/polaris-smart/dph-fleet) — 去中心化多设备舰队：mDNS 同网发现 + 密钥配对 + SSH 跨网直连，任意设备可派单/接单（零 npm 依赖） ⭐2 · `dsh plugin add dph-fleet-0.2.4.tgz`
+- [dsh-background-agents](https://github.com/PerryLink/dsh-background-agents) — 可续跑后台子代理 + 持久多代理团队房间：消息总线、共享任务板、审批门交接，跨重启存活 ⭐5 · `dsh plugin add dsh-background-agents`
 
 <!-- nav:start -->
 ---

--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -15,6 +15,8 @@
 - [dsh-llm-wiki](https://github.com/detpecca/dsh-llm-wiki) — 从 agent 管理 LLM-Wiki 知识库（wiki_search/read/stats/ingest 等） ⭐4 · `dsh plugin add @detpecca/dsh-llm-wiki`
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格）沉淀自会话轨迹，带审查门禁与技能热加载 ⭐12 · `dsh plugin add dsh-continual-evolve`
 - [dsh-meow-memory](https://github.com/Phant0Meow/dsh-meow-memory) — 跨会话项目记忆：SQLite 分层存储 + 关键词/语义检索，逐消息命中注入与窗口期整理 ⭐10 · `dsh plugin add github:Phant0Meow/dsh-meow-memory`
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) — 有界分层审批门跨会话记忆：ctx.memory 服务 + 零依赖 SQLite provider + 冻结快照注入 ⭐57 · `dsh plugin add dsh-memento`
+- [dsh-library](https://github.com/PerryLink/dsh-library) — 本地文档知识库：语义+关键词混合检索、多样性重排、引用感知注入，SQLite 索引零模型下载 ⭐1 · `dsh plugin add dsh-library`
 
 ## 上下文审计 / 压缩 / 蒸馏
 
@@ -34,6 +36,8 @@
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) — 跨 dsh/Codex/Claude/pi/OpenCode 会话的无索引全文搜索 ⭐2
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话 ⭐68 · `dsh plugin add dsh-chat-import`
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) — 迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH ⭐6 · `dsh plugin add dsh-claude-move`
+- [dsh-checkpoint-rewind](https://github.com/PerryLink/dsh-checkpoint-rewind) — DSH 版 /rewind：git 优先工作区快照 + 轮边界会话 fork + /checkpoint、/rewind 一键恢复 ⭐8 · `dsh plugin add dsh-checkpoint-rewind`
+- [dsh-session-sync](https://github.com/PerryLink/dsh-session-sync) — 会话跨设备同步：专用 git 镜像 + append-only 三方合并（keep-both + fork 冲突解决） ⭐1 · `dsh plugin add dsh-session-sync`
 
 <!-- nav:start -->
 ---

--- a/plugins/infrastructure-dev.md
+++ b/plugins/infrastructure-dev.md
@@ -21,6 +21,9 @@
 - [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) — 本机安全审计：配置/插件来源/会话/网络暴露面，只读脱敏报告 ⭐12 · `dsh plugin add @deepseek-ai/dsh-security-audit`
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) — 会话文件帧级扫描诊断（torn/损坏/空会话检测） ⭐8 · `dsh plugin add @deepseek-ai/dsh-session-health`
 - [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — dsh 登录网关（密码门）：远程访问鉴权 + 多用户账号管理，HTTPS/防爆破/审计日志 ⭐11 · `dsh plugin add github:slywalker2006/dsh-passwords`
+- [dsh-fast](https://github.com/PerryLink/dsh-fast) — 只读性能诊断：会话加载耗时、spill 命中、压缩统计、上下文注入量、缓存命中率 · `dsh plugin add dsh-fast`
+- [dsh-test-drive](https://github.com/PerryLink/dsh-test-drive) — 插件隔离安装冒烟：一次性 DSH_HOME 内安装+patch 校验+启动，产出结构化结果矩阵 · `dsh plugin add dsh-test-drive`
+- [dsh-score](https://github.com/PerryLink/dsh-score) — 插件五维质量评分（安装/维护/文档/安全/协议合规），真实 CLI 证据 + 榜单报告 · `dsh plugin add dsh-score`
 
 ## 运行时 / 沙箱 / 遥测 / hook
 
@@ -36,6 +39,8 @@
 - [dsh-dev-actions](https://github.com/skitse/dsh-dev-actions) — Agent 提议的可复用开发命令，转为侧栏动作 ⭐1 · `dsh plugin add dsh-dev-actions`
 - [dsh-tool-policy](https://github.com/Drifter-yh/dsh-tool-policy) — 声明式默认拒绝的工具策略 ⭐3 · `dsh plugin add dsh-tool-policy`
 - [dsh-openai-codex-auth](https://github.com/yoke233/dsh-openai-codex-auth) — OpenAI Codex OAuth 登录与用量卡 ⭐6 · `dsh plugin add dsh-openai-codex-auth`
+- [dsh-observe](https://github.com/PerryLink/dsh-observe) — OpenTelemetry/Langfuse 可观测性导出：span 与 token/成本指标，脱敏采集 + 离线缓冲 · `dsh plugin add dsh-observe`
+- [dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) — 声明式 allow/deny/ask 权限规则 + 进程级网络策略（内置本地代理），全量审计 + 热重载 ⭐8 · `dsh plugin add dsh-permission-rules`
 
 ## 分发 / 运维 / 迁移
 
@@ -46,6 +51,7 @@
 - [session-persistence-rdb](https://github.com/morlay/session-persistence-rdb) — session 关系型数据库持久化 ⭐4 · `dsh plugin add @morlay/session-persistence-rdb`
 - [dsh-market](https://github.com/dsh-market/dsh-market) — DSH 可视化插件市场：浏览/搜索/一键安装 ⭐1031 · `dsh plugin add github:dsh-market/dsh-market`
 - [dsh-webui-market-plugin](https://github.com/Sanqi-normal/dsh-webui-market-plugin) — dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin 目录/安装/卸载 ⭐87 · `dsh plugin add github:Sanqi-normal/dsh-webui-market-plugin`
+- [dsh-github](https://github.com/PerryLink/dsh-github) — 官方级 GitHub CI：composite action + 轮询 PR 审查机器人 + 状态检查门，写操作全过审批 ⭐3 · `dsh plugin add @perrylink/dsh-github`
 
 <!-- nav:start -->
 ---

--- a/plugins/mcp.md
+++ b/plugins/mcp.md
@@ -10,6 +10,7 @@
 - [shadow-vision](https://github.com/WardLu/shadow-vision) — 开源 MCP 视觉 server，给纯文本 LLM 图片理解/OCR/UI 检查 ⭐2
 - [mcp-bridge](https://github.com/WongJingGitt/mcp-bridge) — MCP 浏览器桥接，让网页端 AI 调用 MCP 工具 ⭐31
 - [dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) — BitFun 与 DSH 的 ACP 交互对接 ⭐9 · `dsh plugin add dsh-acp-for-bitfun`
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) — 官方 MCP 客户端管理台：/mcp 健康诊断 + 设置页服务器 CRUD（审批门 + 自动备份）+ 工具试调台 ⭐10 · `dsh plugin add dsh-mcp-panel`
 
 <!-- nav:start -->
 ---

--- a/plugins/multimodal.md
+++ b/plugins/multimodal.md
@@ -19,6 +19,8 @@
 - [dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — 原生鸿蒙设备桥：hdc 截图-看图-装包-验证闭环调试 ⭐11 · `dsh plugin add dsh-hdc-bridge`
 - [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) — provider 无关的 AIGC HTTP 桥 + 自由画布 + ffmpeg 后处理 ⭐12 · `dsh plugin add @huanlin/dsh-plugin-aigc-canvas`
 - [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) — 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） ⭐752 · `dsh plugin add dsh-vision-router`
+- [dsh-draw](https://github.com/PerryLink/dsh-draw) — 统一静态图像生成路由：image_generate 接 OpenAI 兼容引擎，健康感知回退 + 会话配额 + 结果卡片 · `dsh plugin add dsh-draw`
+- [dsh-click](https://github.com/PerryLink/dsh-click) — 原生桌面控制（Windows 优先）：截图/无障碍读屏/点击/输入/应用启动，变更全过审批门 · `dsh plugin add dsh-click`
 
 <!-- nav:start -->
 ---

--- a/plugins/skills.md
+++ b/plugins/skills.md
@@ -18,6 +18,8 @@
 - [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 逆向工程、授权渗透测试与安全研究技能路由包（85 个 SKILL.md，仅限授权测试） ⭐36 · `dsh plugin add github:dhicoc/dsh-reverse-skill`
 - [dsh-find-plugins](https://github.com/Nagi-ovo/dsh-find-plugins) — 帮 DSH 搜索、安装并验证 GitHub 插件的 Skill ⭐145 · `dsh plugin add github:Nagi-ovo/dsh-find-plugins`
 - [forkprobe](https://github.com/Jayden-X-L/forkprobe) — 同一任务对比多个 skill 并选出最优 ⭐67 · `dsh plugin add github:Jayden-X-L/forkprobe`
+- [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) — 插件开发知识库打包为按需 agent 技能：官方约束、任务工作流、API 参考与社区踩坑 ⭐4 · `dsh plugin add dsh-plugin-guide`
+- [dsh-skill-pack-security](https://github.com/PerryLink/dsh-skill-pack-security) — 安全审计技能包 + plugin_vet 供应链门禁：八个双语技能 + 预安装自动扫描 ⭐2 · `dsh plugin add @perrylink/dsh-skill-pack-security-provider`
 
 <!-- nav:start -->
 ---

--- a/plugins/tools.md
+++ b/plugins/tools.md
@@ -32,6 +32,11 @@
 - [dsh-plugin-sleep](https://github.com/HuanLinOTO/dsh-plugin-sleep) — 暴露单个 `sleep` 工具，让模型按需暂停（支持取消） ⭐9 · `dsh plugin add @huanlin/dsh-plugin-sleep`
 - [dsh-port-guard](https://github.com/PangYiMing/dsh-port-guard) — 端口占用处置（复用/切换/精确 kill） ⭐1 · `dsh plugin add dsh-port-guard`
 - [dsh-scout](https://github.com/omdsh-dev/dsh-scout) — 只读环境探测：运行环境/版本/资源/端口/服务/硬件/工作区 ⭐2 · `dsh plugin add @deepseek-ai/dsh-tool-scout`
+- [dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions) — LSP 动作面：诊断/格式化/补全/代码动作/符号/签名提示/inlay/重命名，真实语言服务器驱动 ⭐5 · `dsh plugin add dsh-lsp-actions`
+- [dsh-translate](https://github.com/PerryLink/dsh-translate) — 跨 11 家厂商的参数翻译 + 确定性 JSON 修复（fix_json），绝不编造数据 · `dsh plugin add dsh-translate`
+- [dsh-defend](https://github.com/PerryLink/dsh-defend) — 提示注入/越狱/密钥泄露检测：Aho-Corasick 引擎三道缝 allow/ask/block 拦截 + 脱敏审计 · `dsh plugin add dsh-defend`
+- [dsh-mask](https://github.com/PerryLink/dsh-mask) — PII 脱敏中间件：敏感信息到达模型前匿名化为占位符，展示层还原，绝不记录明文 · `dsh plugin add dsh-mask`
+- [dsh-budget](https://github.com/PerryLink/dsh-budget) — 成本治理：按模型/会话/日聚合计量，预算上限 + 阈值告警 + 超限策略，/budget 命令 ⭐1 · `dsh plugin add dsh-budget`
 
 <!-- nav:start -->
 ---

--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -46,6 +46,10 @@
 - [dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) — 把 open-mcp-apps 带进 DSH：每个 MCP app 一个侧边栏容器（独立 workspace + 会话 + App mode），带 agent 状态条、聊天内行内渲染与 App Store · `dsh plugin --profile web add @2nd1st/dsh-plugin-open-app` ⭐3
 - [dsh-ui-hub](https://github.com/Han-1413141/dsh-ui-hub) — UI 管家：官方/插件 UI 分区折叠、逐条开关，拖拽移动/改大小，碰撞避让与一键自动排布 · `dsh plugin --profile web add github:Han-1413141/dsh-ui-hub` ⭐2
 - [dsh-what-changed](https://github.com/sjh9714/dsh-what-changed) — 会话顶栏一屏看完整会话改动，列出 Agent 写过的每个文件与逐处改动，被权限拒绝的写入单独计数不算改动 · `dsh plugin --profile web add dsh-what-changed` ⭐2
+- [dsh-composer-history](https://github.com/PerryLink/dsh-composer-history) — 网页输入区终端式输入历史：方向键还原草稿/光标、Ctrl+R 反搜、工作区级回忆 ⭐6 · `dsh plugin add dsh-composer-history`
+- [dsh-output-styles](https://github.com/PerryLink/dsh-output-styles) — 运行时切换输出风格（对齐 Claude Code outputStyles）+ output.render.* 呈现协议 + /style ⭐3 · `dsh plugin add dsh-output-styles`
+- [dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) — 置顶会话/工作区到侧边栏：行配色、看板/标签/已存视图、健康摘要与 /goto ⭐2 · `dsh plugin add dsh-session-pin`
+- [dsh-talk](https://github.com/PerryLink/dsh-talk) — 语音优先会话回路：输入区麦克风（浏览器/本地 STT）+ TTS 播报 + 事件播报 + 说话打断 · `dsh plugin add dsh-talk`
 
 ## 生成式 UI / 组件
 

--- a/plugins/workflow-automation.md
+++ b/plugins/workflow-automation.md
@@ -23,6 +23,9 @@
 - [dsh-tiered-approval](https://github.com/Elaina-real/dsh-tiered-approval) — 分层自动审查：静态规则 + LLM 审查 + 人工兜底 ⭐2 · `dsh plugin add dsh-tiered-approval`
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) — 事件流审计面板：观察事件类型/分发模式/计数，帮插件作者理解内部 ⭐1 · `dsh plugin add @dsh-external/dsh-event-auditor`
 - [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) — 自动续传：网络中断后自动发「继续」恢复请求 ⭐25 · `dsh plugin add github:HsiangNianian/dsh-auto-continue`
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) — 交付质量门：审讯需求→红绿测试证据门→对抗评审→逐维核验报告 ⭐4 · `dsh plugin add dsh-doublecheck`
+- [dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) — 审批链第二模型自动审查：只读子代理返回带理由的 allow/deny 结构化裁决，fail-closed ⭐36 · `dsh plugin add dsh-auto-review`
+- [dsh-local-ai](https://github.com/PerryLink/dsh-local-ai) — Ollama 本地模型集成：发现/拉取/查看，按任务或关键词路由并自动回退云端，/ollama 总览 ⭐1 · `dsh plugin add dsh-local-ai`
 
 <!-- nav:start -->
 ---

--- a/web/data.js
+++ b/web/data.js
@@ -1,12 +1,12 @@
 // 由 scripts/gen-web-data.mjs 自动生成，请勿手改。
 window.__DSH_DATA__ = {
-  "generatedAt": "2026-08-18T18:19:06.955Z",
+  "generatedAt": "2026-08-19T01:42:36.171Z",
   "source": "scripts/gen-web-data.mjs",
   "stats": {
-    "plugins": 299,
+    "plugins": 327,
     "categories": 14,
-    "withInstall": 228,
-    "withStars": 298
+    "withInstall": 256,
+    "withStars": 316
   },
   "categories": [
     {
@@ -424,6 +424,56 @@ window.__DSH_DATA__ = {
       "category": "tools"
     },
     {
+      "name": "dsh-lsp-actions",
+      "url": "https://github.com/PerryLink/dsh-lsp-actions",
+      "owner": "PerryLink",
+      "repo": "dsh-lsp-actions",
+      "description": "LSP 动作面：诊断/格式化/补全/代码动作/符号/签名提示/inlay/重命名，真实语言服务器驱动",
+      "stars": 5,
+      "install": "dsh plugin add dsh-lsp-actions",
+      "category": "tools"
+    },
+    {
+      "name": "dsh-translate",
+      "url": "https://github.com/PerryLink/dsh-translate",
+      "owner": "PerryLink",
+      "repo": "dsh-translate",
+      "description": "跨 11 家厂商的参数翻译 + 确定性 JSON 修复（fix_json），绝不编造数据",
+      "stars": null,
+      "install": "dsh plugin add dsh-translate",
+      "category": "tools"
+    },
+    {
+      "name": "dsh-defend",
+      "url": "https://github.com/PerryLink/dsh-defend",
+      "owner": "PerryLink",
+      "repo": "dsh-defend",
+      "description": "提示注入/越狱/密钥泄露检测：Aho-Corasick 引擎三道缝 allow/ask/block 拦截 + 脱敏审计",
+      "stars": null,
+      "install": "dsh plugin add dsh-defend",
+      "category": "tools"
+    },
+    {
+      "name": "dsh-mask",
+      "url": "https://github.com/PerryLink/dsh-mask",
+      "owner": "PerryLink",
+      "repo": "dsh-mask",
+      "description": "PII 脱敏中间件：敏感信息到达模型前匿名化为占位符，展示层还原，绝不记录明文",
+      "stars": null,
+      "install": "dsh plugin add dsh-mask",
+      "category": "tools"
+    },
+    {
+      "name": "dsh-budget",
+      "url": "https://github.com/PerryLink/dsh-budget",
+      "owner": "PerryLink",
+      "repo": "dsh-budget",
+      "description": "成本治理：按模型/会话/日聚合计量，预算上限 + 阈值告警 + 超限策略，/budget 命令",
+      "stars": 1,
+      "install": "dsh plugin add dsh-budget",
+      "category": "tools"
+    },
+    {
       "name": "dsh-review-skills",
       "url": "https://github.com/ben7am1n/dsh-review-skills",
       "owner": "ben7am1n",
@@ -584,6 +634,26 @@ window.__DSH_DATA__ = {
       "category": "skills"
     },
     {
+      "name": "dsh-plugin-guide",
+      "url": "https://github.com/PerryLink/dsh-plugin-guide",
+      "owner": "PerryLink",
+      "repo": "dsh-plugin-guide",
+      "description": "插件开发知识库打包为按需 agent 技能：官方约束、任务工作流、API 参考与社区踩坑",
+      "stars": 4,
+      "install": "dsh plugin add dsh-plugin-guide",
+      "category": "skills"
+    },
+    {
+      "name": "dsh-skill-pack-security",
+      "url": "https://github.com/PerryLink/dsh-skill-pack-security",
+      "owner": "PerryLink",
+      "repo": "dsh-skill-pack-security",
+      "description": "安全审计技能包 + plugin_vet 供应链门禁：八个双语技能 + 预安装自动扫描",
+      "stars": 2,
+      "install": "dsh plugin add @perrylink/dsh-skill-pack-security-provider",
+      "category": "skills"
+    },
+    {
       "name": "dsh-mcp-proxy",
       "url": "https://github.com/ben7am1n/dsh-mcp-proxy",
       "owner": "ben7am1n",
@@ -661,6 +731,16 @@ window.__DSH_DATA__ = {
       "description": "BitFun 与 DSH 的 ACP 交互对接",
       "stars": 9,
       "install": "dsh plugin add dsh-acp-for-bitfun",
+      "category": "mcp"
+    },
+    {
+      "name": "dsh-mcp-panel",
+      "url": "https://github.com/PerryLink/dsh-mcp-panel",
+      "owner": "PerryLink",
+      "repo": "dsh-mcp-panel",
+      "description": "官方 MCP 客户端管理台：/mcp 健康诊断 + 设置页服务器 CRUD（审批门 + 自动备份）+ 工具试调台",
+      "stars": 10,
+      "install": "dsh plugin add dsh-mcp-panel",
       "category": "mcp"
     },
     {
@@ -1054,6 +1134,46 @@ window.__DSH_DATA__ = {
       "category": "ui-themes"
     },
     {
+      "name": "dsh-composer-history",
+      "url": "https://github.com/PerryLink/dsh-composer-history",
+      "owner": "PerryLink",
+      "repo": "dsh-composer-history",
+      "description": "网页输入区终端式输入历史：方向键还原草稿/光标、Ctrl+R 反搜、工作区级回忆",
+      "stars": 6,
+      "install": "dsh plugin add dsh-composer-history",
+      "category": "ui-themes"
+    },
+    {
+      "name": "dsh-output-styles",
+      "url": "https://github.com/PerryLink/dsh-output-styles",
+      "owner": "PerryLink",
+      "repo": "dsh-output-styles",
+      "description": "运行时切换输出风格（对齐 Claude Code outputStyles）+ output.render.* 呈现协议 + /style",
+      "stars": 3,
+      "install": "dsh plugin add dsh-output-styles",
+      "category": "ui-themes"
+    },
+    {
+      "name": "dsh-session-pin",
+      "url": "https://github.com/PerryLink/dsh-session-pin",
+      "owner": "PerryLink",
+      "repo": "dsh-session-pin",
+      "description": "置顶会话/工作区到侧边栏：行配色、看板/标签/已存视图、健康摘要与 /goto",
+      "stars": 2,
+      "install": "dsh plugin add dsh-session-pin",
+      "category": "ui-themes"
+    },
+    {
+      "name": "dsh-talk",
+      "url": "https://github.com/PerryLink/dsh-talk",
+      "owner": "PerryLink",
+      "repo": "dsh-talk",
+      "description": "语音优先会话回路：输入区麦克风（浏览器/本地 STT）+ TTS 播报 + 事件播报 + 说话打断",
+      "stars": null,
+      "install": "dsh plugin add dsh-talk",
+      "category": "ui-themes"
+    },
+    {
       "name": "dsh-visualize",
       "url": "https://github.com/Nagi-ovo/dsh-visualize",
       "owner": "Nagi-ovo",
@@ -1414,6 +1534,16 @@ window.__DSH_DATA__ = {
       "category": "agent-orchestration"
     },
     {
+      "name": "dsh-background-agents",
+      "url": "https://github.com/PerryLink/dsh-background-agents",
+      "owner": "PerryLink",
+      "repo": "dsh-background-agents",
+      "description": "可续跑后台子代理 + 持久多代理团队房间：消息总线、共享任务板、审批门交接，跨重启存活",
+      "stars": 5,
+      "install": "dsh plugin add dsh-background-agents",
+      "category": "agent-orchestration"
+    },
+    {
       "name": "dsh-memory-evolve",
       "url": "https://github.com/csyangwen/dsh-memory-evolve",
       "owner": "csyangwen",
@@ -1521,6 +1651,26 @@ window.__DSH_DATA__ = {
       "description": "跨会话项目记忆：SQLite 分层存储 + 关键词/语义检索，逐消息命中注入与窗口期整理",
       "stars": 10,
       "install": "dsh plugin add github:Phant0Meow/dsh-meow-memory",
+      "category": "context-memory"
+    },
+    {
+      "name": "dsh-memento",
+      "url": "https://github.com/PerryLink/dsh-memento",
+      "owner": "PerryLink",
+      "repo": "dsh-memento",
+      "description": "有界分层审批门跨会话记忆：ctx.memory 服务 + 零依赖 SQLite provider + 冻结快照注入",
+      "stars": 57,
+      "install": "dsh plugin add dsh-memento",
+      "category": "context-memory"
+    },
+    {
+      "name": "dsh-library",
+      "url": "https://github.com/PerryLink/dsh-library",
+      "owner": "PerryLink",
+      "repo": "dsh-library",
+      "description": "本地文档知识库：语义+关键词混合检索、多样性重排、引用感知注入，SQLite 索引零模型下载",
+      "stars": 1,
+      "install": "dsh plugin add dsh-library",
       "category": "context-memory"
     },
     {
@@ -1651,6 +1801,26 @@ window.__DSH_DATA__ = {
       "description": "迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH",
       "stars": 6,
       "install": "dsh plugin add dsh-claude-move",
+      "category": "context-memory"
+    },
+    {
+      "name": "dsh-checkpoint-rewind",
+      "url": "https://github.com/PerryLink/dsh-checkpoint-rewind",
+      "owner": "PerryLink",
+      "repo": "dsh-checkpoint-rewind",
+      "description": "DSH 版 /rewind：git 优先工作区快照 + 轮边界会话 fork + /checkpoint、/rewind 一键恢复",
+      "stars": 8,
+      "install": "dsh plugin add dsh-checkpoint-rewind",
+      "category": "context-memory"
+    },
+    {
+      "name": "dsh-session-sync",
+      "url": "https://github.com/PerryLink/dsh-session-sync",
+      "owner": "PerryLink",
+      "repo": "dsh-session-sync",
+      "description": "会话跨设备同步：专用 git 镜像 + append-only 三方合并（keep-both + fork 冲突解决）",
+      "stars": 1,
+      "install": "dsh plugin add dsh-session-sync",
       "category": "context-memory"
     },
     {
@@ -1821,6 +1991,26 @@ window.__DSH_DATA__ = {
       "description": "纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR）",
       "stars": 752,
       "install": "dsh plugin add dsh-vision-router",
+      "category": "multimodal"
+    },
+    {
+      "name": "dsh-draw",
+      "url": "https://github.com/PerryLink/dsh-draw",
+      "owner": "PerryLink",
+      "repo": "dsh-draw",
+      "description": "统一静态图像生成路由：image_generate 接 OpenAI 兼容引擎，健康感知回退 + 会话配额 + 结果卡片",
+      "stars": null,
+      "install": "dsh plugin add dsh-draw",
+      "category": "multimodal"
+    },
+    {
+      "name": "dsh-click",
+      "url": "https://github.com/PerryLink/dsh-click",
+      "owner": "PerryLink",
+      "repo": "dsh-click",
+      "description": "原生桌面控制（Windows 优先）：截图/无障碍读屏/点击/输入/应用启动，变更全过审批门",
+      "stars": null,
+      "install": "dsh plugin add dsh-click",
       "category": "multimodal"
     },
     {
@@ -2031,6 +2221,36 @@ window.__DSH_DATA__ = {
       "description": "自动续传：网络中断后自动发「继续」恢复请求",
       "stars": 25,
       "install": "dsh plugin add github:HsiangNianian/dsh-auto-continue",
+      "category": "workflow-automation"
+    },
+    {
+      "name": "dsh-doublecheck",
+      "url": "https://github.com/PerryLink/dsh-doublecheck",
+      "owner": "PerryLink",
+      "repo": "dsh-doublecheck",
+      "description": "交付质量门：审讯需求→红绿测试证据门→对抗评审→逐维核验报告",
+      "stars": 4,
+      "install": "dsh plugin add dsh-doublecheck",
+      "category": "workflow-automation"
+    },
+    {
+      "name": "dsh-auto-review",
+      "url": "https://github.com/PerryLink/dsh-auto-review",
+      "owner": "PerryLink",
+      "repo": "dsh-auto-review",
+      "description": "审批链第二模型自动审查：只读子代理返回带理由的 allow/deny 结构化裁决，fail-closed",
+      "stars": 36,
+      "install": "dsh plugin add dsh-auto-review",
+      "category": "workflow-automation"
+    },
+    {
+      "name": "dsh-local-ai",
+      "url": "https://github.com/PerryLink/dsh-local-ai",
+      "owner": "PerryLink",
+      "repo": "dsh-local-ai",
+      "description": "Ollama 本地模型集成：发现/拉取/查看，按任务或关键词路由并自动回退云端，/ollama 总览",
+      "stars": 1,
+      "install": "dsh plugin add dsh-local-ai",
       "category": "workflow-automation"
     },
     {
@@ -2514,6 +2734,36 @@ window.__DSH_DATA__ = {
       "category": "infrastructure-dev"
     },
     {
+      "name": "dsh-fast",
+      "url": "https://github.com/PerryLink/dsh-fast",
+      "owner": "PerryLink",
+      "repo": "dsh-fast",
+      "description": "只读性能诊断：会话加载耗时、spill 命中、压缩统计、上下文注入量、缓存命中率",
+      "stars": null,
+      "install": "dsh plugin add dsh-fast",
+      "category": "infrastructure-dev"
+    },
+    {
+      "name": "dsh-test-drive",
+      "url": "https://github.com/PerryLink/dsh-test-drive",
+      "owner": "PerryLink",
+      "repo": "dsh-test-drive",
+      "description": "插件隔离安装冒烟：一次性 DSH_HOME 内安装+patch 校验+启动，产出结构化结果矩阵",
+      "stars": null,
+      "install": "dsh plugin add dsh-test-drive",
+      "category": "infrastructure-dev"
+    },
+    {
+      "name": "dsh-score",
+      "url": "https://github.com/PerryLink/dsh-score",
+      "owner": "PerryLink",
+      "repo": "dsh-score",
+      "description": "插件五维质量评分（安装/维护/文档/安全/协议合规），真实 CLI 证据 + 榜单报告",
+      "stars": null,
+      "install": "dsh plugin add dsh-score",
+      "category": "infrastructure-dev"
+    },
+    {
       "name": "dsh-evolve",
       "url": "https://github.com/william-jin-cmu/dsh-evolve",
       "owner": "william-jin-cmu",
@@ -2634,6 +2884,26 @@ window.__DSH_DATA__ = {
       "category": "infrastructure-dev"
     },
     {
+      "name": "dsh-observe",
+      "url": "https://github.com/PerryLink/dsh-observe",
+      "owner": "PerryLink",
+      "repo": "dsh-observe",
+      "description": "OpenTelemetry/Langfuse 可观测性导出：span 与 token/成本指标，脱敏采集 + 离线缓冲",
+      "stars": null,
+      "install": "dsh plugin add dsh-observe",
+      "category": "infrastructure-dev"
+    },
+    {
+      "name": "dsh-permission-rules",
+      "url": "https://github.com/PerryLink/dsh-permission-rules",
+      "owner": "PerryLink",
+      "repo": "dsh-permission-rules",
+      "description": "声明式 allow/deny/ask 权限规则 + 进程级网络策略（内置本地代理），全量审计 + 热重载",
+      "stars": 8,
+      "install": "dsh plugin add dsh-permission-rules",
+      "category": "infrastructure-dev"
+    },
+    {
       "name": "deepseek-harness-docker",
       "url": "https://github.com/runzhliu/deepseek-harness-docker",
       "owner": "runzhliu",
@@ -2701,6 +2971,16 @@ window.__DSH_DATA__ = {
       "description": "dsh Web GUI 社区插件市场：浏览 awesome-dsh-plugin 目录/安装/卸载",
       "stars": 87,
       "install": "dsh plugin add github:Sanqi-normal/dsh-webui-market-plugin",
+      "category": "infrastructure-dev"
+    },
+    {
+      "name": "dsh-github",
+      "url": "https://github.com/PerryLink/dsh-github",
+      "owner": "PerryLink",
+      "repo": "dsh-github",
+      "description": "官方级 GitHub CI：composite action + 轮询 PR 审查机器人 + 状态检查门，写操作全过审批",
+      "stars": 3,
+      "install": "dsh plugin add @perrylink/dsh-github",
       "category": "infrastructure-dev"
     },
     {


### PR DESCRIPTION
在 docs/taxonomy.md 中新增收录 PerryLink 的 28 个插件,并用 `scripts/gen-web-data.mjs` 重新生成 `web/data.js`:

- tools:dsh-lsp-actions / dsh-translate / dsh-defend / dsh-mask / dsh-budget
- skills:dsh-plugin-guide / dsh-skill-pack-security
- mcp:dsh-mcp-panel
- multimodal:dsh-draw / dsh-click
- agent-orchestration:dsh-background-agents
- context-memory:dsh-memento / dsh-library(检索/知识)+ dsh-checkpoint-rewind / dsh-session-sync(跨设备/同步)
- ui-themes:dsh-composer-history / dsh-output-styles / dsh-session-pin / dsh-talk
- workflow-automation:dsh-doublecheck / dsh-auto-review / dsh-local-ai
- infrastructure-dev:dsh-fast / dsh-test-drive / dsh-score(质量评分)+ dsh-observe / dsh-permission-rules(权限/命令/网络)+ dsh-github(CI/评审)

全部插件均已打 `dsh-plugin` topic 并支持,`dsh plugin add` 直接安装