### PR TITLE
Add dsh-plugin-usage-meter and dsh-tray-launcher

### DIFF
--- a/plugins/desktop-tui-mobile.md
+++ b/plugins/desktop-tui-mobile.md
@@ -30,6 +30,7 @@
 - [deepseek-harness-desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) — 现代化 DeepSeek Harness 桌面端体验 ⭐15049
 - [Deepseek-Harness-Desktop](https://github.com/ChisaAlter/Deepseek-Harness-Desktop) — Electron 桌面壳：主题/背景图/托盘，对话仍走官方 dsh web ⭐122 · `dsh plugin add deepseek-harness-desktop`
 - [dsh-launcher](https://github.com/Ruler4396/dsh-launcher) — Windows 轻量启动器：开机自启 + 独立小窗口 ⭐153
+- [dsh-tray-launcher](https://github.com/fancr-code/dsh-tray-launcher) — Windows 桌面托盘启动器：无窗口运行 dsh web，托盘右键切换图标（梁祖/鲸鱼娘/DeepSeek/自定义），退出即全退 · `npm i -g dsh-tray-launcher && dsh-tray-install` ⭐2
 
 ## 本地工作台
 

--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -41,6 +41,7 @@
 - [dsh-token-usage](https://github.com/hashdiana/dsh-token-usage) — 更美观的 Token 用量条：上下文占用/输入输出/缓存分解/首字延迟 ⭐3 · `dsh plugin add dsh-token-usage`
 - [TokenLedger](https://github.com/zh667/TokenLedger) — 按中转站点、项目和模型统计本地 DSH Token 用量，并显示账户余额与订阅额度周期 · `dsh plugin --profile web add github:zh667/TokenLedger` ⭐110
 - [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) — RMB/USD token 计费：官方峰谷价自动计价、按 provider/来源分组统计、预算与余额可视、CSV/JSON 导出 · `dsh plugin --profile web add github:bpc-oss/dsh-web-billing` ⭐11
+- [dsh-plugin-usage-meter](https://github.com/fancr-code/dsh-plugin-usage-meter) — API 用量/费用/余额仪表：按钮式用量条（峰/谷时段标签）、当日/近 7 天按模型堆叠柱状图、模型分布、预算提醒与跨会话账本 · `dsh plugin add dsh-plugin-usage-meter` ⭐2
 - [dsh-model-config-sync](https://github.com/LiangYin233/dsh-provider-model-configurator) — 高级模型配置器：把 pi-ai 预设一键应用到自定义提供商 ⭐10 · `dsh plugin add dsh-model-config-sync`
 - [dsh-web-ui](https://github.com/zhu1090093659/dsh-web-ui) — DSH Web UI 插件与皮肤集合：任务看板、Git 图谱、右侧面板、移动端远程、皮肤中心 ⭐4863 · `dsh plugin add dsh-web-ui`
 - [dsh-plugin-open-app](https://github.com/2nd1st/dsh-plugin-open-app) — 把 open-mcp-apps 带进 DSH：每个 MCP app 一个侧边栏容器（独立 workspace + 会话 + App mode），带 agent 状态条、聊天内行内渲染与 App Store · `dsh plugin --profile web add @2nd1st/dsh-plugin-open-app` ⭐3


### PR DESCRIPTION
按 CONTRIBUTING 规范新增两个条目：

- **dsh-plugin-usage-meter**（plugins/ui-themes.md，界面增强/面板）— API 用量/费用/余额仪表：按钮式用量条（峰/谷时段标签）、当日/近 7 天按模型堆叠柱状图、模型分布、预算提醒与跨会话账本；npm: \dsh plugin add dsh-plugin-usage-meter\
- **dsh-tray-launcher**（plugins/desktop-tui-mobile.md，桌面壳）— Windows 桌面托盘启动器：无窗口运行 dsh web，托盘右键切换图标（梁祖/鲸鱼娘/DeepSeek/自定义），退出即全退；npm: \
pm i -g dsh-tray-launcher\

两者均为公开 GitHub 仓库、MIT 协议、npm 已发布。