### PR TITLE
Add dsh-plugin-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Top community plugins by GitHub stars:
 | 8 | [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI) | Claude Code-style full-screen terminal UI: pixel-whale header, live status line, and streaming thought expansion. | 2140 |
 | 9 | [deepseek-pp](https://github.com/zhu1090093659/deepseek-pp) | Browser-extension AI agent workspace with built-in MCP and memory | 1638 |
 | 10 | [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | Whale-girl skin series for the DSH Web UI (maid-atelier). | 1486 |
+| 11 | [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) | DSH plugin manager & marketplace: one-click enable/disable, multi-source market, static index (500+ plugins / 300 skills), skill install/disable, suite assembly, framework upgrade adapter | 62 |
 
 <!-- hot:end -->
 

--- a/plugins/infrastructure-dev.md
+++ b/plugins/infrastructure-dev.md
@@ -11,6 +11,7 @@
 - [dsh-plugin-installer](https://github.com/Toukaiteio/dsh-plugin-installer) — 把 DSH 快速接入 GitHub 插件生态的市场插件 ⭐6 · `dsh plugin add dsh-plugin-installer`
 - [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) — 超级模组注入器：运行时注入本地插件包（junction + loader.create，热重载） ⭐125 · `dsh plugin add @dsh-external/dsh-super-injector`
 - [oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) — 面向 DSH 的插件生态：700+ 插件，扩展接缝注册不改 agent-loop ⭐51
+- [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — 插件管理面板 + 多源市场：一键启停（HMR 生效）、GitHub/Gitee/自定义源并行搜索、静态索引市场（500+ 插件 / 300 技能）、技能安装/停用/删除、套装一键装配、框架一键升级 ⭐62
 
 ## 健康检查 / 诊断 / 审计
 


### PR DESCRIPTION
﻿## 收录申请：dsh-plugin-hub

[Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — DSH 插件管理面板与市场：

- 一键启用/停用已安装插件（HMR 生效），基础设施保护
- 多源插件市场：GitHub / Gitee 直装 / 自定义搜索源、多源汇总、★ 官方筛选
- 静态索引市场：jsDelivr CDN 分发 500+ 插件 / 300 技能，零 GitHub API 调用
- 技能市场：搜索（agent-skills/claude-skills/dsh-skill）、一键安装/停用/删除、系统保护
- 套装（submodule 聚合仓库）一键装配：bundle 插件 / 技能 / agent 预设 / 普通插件
- 自动收录 CI（每 6 小时刷新索引）、框架一键升级（在线安装 + 失败自动回滚）
- 已打 dsh-plugin topic

本次改动：在 `plugins/infrastructure-dev.md`「插件管理 / 注册表 / 市场」分类下新增条目（基于最新主仓库结构）。

感谢收录！
