### PR TITLE
收录 dsh-labnana(多模态/图片生成)

### DIFF
--- a/plugins/multimodal.md
+++ b/plugins/multimodal.md
@@ -19,6 +19,7 @@
 - [dsh-hdc-bridge](https://github.com/1na-ko/dsh-hdc-bridge) — 原生鸿蒙设备桥：hdc 截图-看图-装包-验证闭环调试 ⭐12 · `dsh plugin add dsh-hdc-bridge`
 - [dsh-plugin-aigc-canvas](https://github.com/HuanLinOTO/dsh-plugin-aigc-canvas) — provider 无关的 AIGC HTTP 桥 + 自由画布 + ffmpeg 后处理 ⭐15 · `dsh plugin add @huanlin/dsh-plugin-aigc-canvas`
 - [dsh-vision-router](https://github.com/ysr666/dsh-vision-router) — 纯文本模型的视觉路由：免费视觉链 + 像素级视觉工具（问答/定位/裁剪/OCR） ⭐935 · `dsh plugin add dsh-vision-router`
+- [dsh-labnana](https://github.com/exoticknight/dsh-labnana) — Labnana 图片生成插件：文生图/图生图/精准编辑，支持 NanoBanana Pro、GPT-Image-2、Wan2.7、Seedream，对话内图片卡片 + 积分预估 · `dsh plugin add github:exoticknight/dsh-labnana`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
在 plugins/multimodal.md 追加 dsh-labnana：为 DeepSeek Harness 接入 Labnana 图片生成(文生图/图生图/精准编辑)，支持 NanoBanana Pro、GPT-Image-2、Wan2.7、Seedream。