### PR TITLE
Add task-chime: DSH task chime plugin (approval & task-complete sounds)

### DIFF
--- a/plugins/notifications-channels.md
+++ b/plugins/notifications-channels.md
@@ -21,6 +21,7 @@
 - [dsh-session-notification](https://github.com/dingyi222666/dsh-session-notification) — 会话完成等四种状态通知，支持浏览器提示 ⭐15 · `dsh plugin add @dingyi222666/dsh-session-notification`
 
 - [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) — 生命周期事件铃声 + 右下角呼吸状态点（Web Audio 合成，零音频文件，可上传自定义音） ⭐2 · `dsh plugin add github:Laplace-bit/dsh-bell-notify`
+- [task-chime](https://github.com/Abel-86/task-chime) — 审批/权限请求与任务完成提示音，GUI 设置中可自定义声音、音量与冷却 ⭐0 · `dsh plugin add task-chime`
 
 ## 远程 / 集成 / 分享
 


### PR DESCRIPTION
## 新增插件

- [task-chime](https://github.com/Abel-86/task-chime) — 审批/权限请求与任务完成提示音，GUI 设置中可自定义声音、音量与冷却

### 说明
- DSH 双半包插件（宿主半 index.mjs + 浏览器半 lib/client.js）
- 已发布 npm：\dsh plugin add task-chime\
- 监听 approval/asked 与 turn/end 事件，通过 Windows MCI 播放本地 mp3/wav
- 设置卡片位于：设置 → 插件 → 插件配置 → DSH 任务提示音