### PR TITLE
tools: 新增 dsh-nuke-plugin（事务化强力卸载引擎）

### DIFF
--- a/plugins/tools.md
+++ b/plugins/tools.md
@@ -37,3 +37,4 @@
 ---
 ← [上一类: 🏛️ 官方核心与元项目](official-meta.md) · [返回目录](../README.md) · [下一类: 🧩 技能类 Skills](skills.md) →
 <!-- nav:end -->
+- [dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) — 事务化强力卸载引擎：每个破坏性动作走 validate/preview/execute/undo 四段式 + Saga 回滚，WAL 崩溃自恢复、hash chain 审计链、硬链接去重、贝叶斯先知推演成功率；回收区代替物理删除（可恢复） · `dsh plugin add beijingwahw/dsh-nuke-plugin`


### PR DESCRIPTION
在 `plugins/tools.md`（🛠️ 工具类）末尾追加一行。

**解决什么问题**：插件装卸残留越积越多、手工清理怕误删、脚本清理不可逆。

**一句话**：事务化强力卸载引擎——每个破坏性动作走 validate/preview/execute/undo 四段式 + Saga 回滚，WAL 崩溃自恢复、hash chain 审计链、硬链接去重、贝叶斯先知推演成功率；回收区代替物理删除（可恢复）。

门槛自检：DSH 专属插件（`dsh plugin add beijingwahw/dsh-nuke-plugin --profile web` 安装，dsh.bundle manifest）✅ 公开仓库 ✅ README + 可运行代码（21 工具 / 222 测试 / MIT）✅

分类说明：与现有 dsh-safe-delete 同属「安全删除」边界（回收区代替物理删除），故入 tools。