### PR TITLE
Add dsh-worktree

### DIFF
--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -48,6 +48,7 @@
 - [dsh-what-changed](https://github.com/sjh9714/dsh-what-changed) — 会话顶栏一屏看完整会话改动，列出 Agent 写过的每个文件与逐处改动，被权限拒绝的写入单独计数不算改动 · `dsh plugin --profile web add dsh-what-changed` ⭐2
 - [dsh-easyrewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) — DSH Web 用户消息气泡内联编辑与撤回：惰性提交、无痕替换、版本翻页器、草稿自动备份、三语 i18n ⭐70 · `dsh plugin add dsh-easyrewrite`
 - [dsh-meow-smooth](https://github.com/Phant0Meow/dsh-meow-smooth) — 手机优先的 DSH 前端体验优化：输入框失焦自动折叠、手机回车换行、侧边栏/顶部栏压缩、设置页适配、禁缩放回弹，外加长任务完成/权限申请/提问通知（Web Push/Bark webhook） ⭐16 · `dsh plugin add meow-smooth`
+- [dsh-worktree](https://github.com/alpacachen/dsh-worktree) — 极简 Git worktree 管理：一个按钮和一个对话框创建任务分支 worktree，并直接打开为 DSH Workspace · `dsh plugin --profile web add @alpacachen/dsh-simple-worktree`
 
 ## 生成式 UI / 组件
 


### PR DESCRIPTION
## Summary

Adds [`alpacachen/dsh-worktree`](https://github.com/alpacachen/dsh-worktree) to the Web UI enhancements directory.

The plugin provides a minimal dialog for creating task-branch Git worktrees and opening them directly as DSH Workspaces.

## Installation

```bash
dsh plugin --profile web add @alpacachen/dsh-simple-worktree
```

## Checks

- Public GitHub repository with working code and README
- `dsh-plugin` topic present
- Declares a `dsh.bundle` manifest
- Published to npm as `@alpacachen/dsh-simple-worktree@1.0.2`
- Build, typecheck, unit tests, client bundle and package-content checks pass
