### PR TITLE
feat: 收录 dsh-agent-team

### DIFF
--- a/plugins/agent-orchestration.md
+++ b/plugins/agent-orchestration.md
@@ -12,6 +12,7 @@
 - [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) — 可配置子代理 profiles + 实时工具调用/token 显示 + 子会话跳转 ⭐15 · `dsh plugin add @huanlin/dsh-plugin-yet-another-subagent`
 - [dsh-a2a](https://github.com/dpskh/dsh-a2a) — Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 ⭐7
 - [dsh-devices](https://github.com/polaris-smart/dsh-devices) — 去中心化多设备舰队：mDNS 同网发现 + 密钥配对 + SSH 跨网直连 + SFTP 文件传输，dsh 会话内自动注册 6 个 fleet 工具（零 npm 依赖） ⭐6 · `dsh plugin add dsh-devices`
+- [dsh-agent-team](https://github.com/wowyuarm/dsh-agent-team) — 帮 human 有序管理任务、把 agents 用成真正的协作者：持久身份 Agent、Workspace 按项目组织、Channel 职责分派、Task Thread 串联推进 ⭐1 · `dsh plugin add @wowyuarm/dsh-agent-team`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
收录自己的插件（作者自荐）：

**dsh-agent-team**（@wowyuarm/dsh-agent-team）— 帮 human 有序管理任务的 Agent Team 插件：Agent 是持久身份，Workspace 按项目组织 agents/sessions，human 通过 Channel 与职责分派管理协作，Task Thread 把多个 session agent 串成一条推进线。

- 分类：agent-orchestration（多 Agent 协作）
- 安装：`dsh plugin add @wowyuarm/dsh-agent-team`（npm 0.1.1，2026-08-26 发布）
- 已认证 DSH `0.1.1-rc.2`（全新 profile 安装 + `--dump-config` 组合树验证）；MIT；带 `dsh-plugin` topic 与完整 README（中英双语）
- 仅改动 `plugins/agent-orchestration.md` 一行