### PR TITLE
新增插件：dsh-qingagent（工具类）

### DIFF
--- a/plugins/tools.md
+++ b/plugins/tools.md
@@ -33,6 +33,7 @@
 - [dsh-port-guard](https://github.com/PangYiMing/dsh-port-guard) — 端口占用处置（复用/切换/精确 kill） ⭐1 · `dsh plugin add dsh-port-guard`
 - [dsh-scout](https://github.com/omdsh-dev/dsh-scout) — 只读环境探测：运行环境/版本/资源/端口/服务/硬件/工作区 ⭐2 · `dsh plugin add @deepseek-ai/dsh-tool-scout`
 - [dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) — 事务化强力卸载引擎：每个破坏性动作走 validate/preview/execute/undo 四段式 + Saga 回滚，WAL 崩溃自恢复、hash chain 审计链、硬链接去重、贝叶斯先知推演成功率；回收区代替物理删除（可恢复） ⭐1 · `dsh plugin add github:beijingwahw/dsh-nuke-plugin`
+- [dsh-qingagent](https://github.com/void2anything/dsh-qingagent) — 把开源 AI 写作客户端青简（QingAgent）接进 DSH：对话里起草改稿，右侧宣纸面板排版渲染（mermaid/drawio/表格/KaTeX），每处修改先摆在纸上供审阅、提交才落稿，10 个工具；需本机运行青简桌面客户端 ⭐2 · `dsh plugin add dsh-qingagent`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
<!-- 感谢贡献！提交前请逐项确认： -->
- [x] 插件未在目录中重复收录（先在对应分类文件里搜一下）
- [x] 分类符合 [docs/taxonomy.md](docs/taxonomy.md) 的边界
- [x] 描述一句话说清「解决什么问题」
- [x] 链接为公开 GitHub 仓库

### 变更类型
- [x] 新增插件
- [ ] 修正分类 / 描述
- [ ] 删除已失效条目
- [ ] 其他

### 说明
在工具类（`plugins/tools.md`）末尾新增 [dsh-qingagent](https://github.com/void2anything/dsh-qingagent)：把开源 AI 写作客户端青简（QingAgent）接进 DSH，对话里起草改稿，右侧宣纸面板排版渲染（mermaid/drawio/表格/KaTeX），每处修改先摆在纸上供审阅、提交才落稿。

补充信息：
- 分类理由：核心是面向模型的 10 个确定性文档工具（qing_ 前缀：write_draft/edit_draft/read_draft/review_commit 等），与同分类的 dsh-cowork、dsh-plugin-mineru 属同类文档工具；目录暂无写作类，若维护者认为归属其它分类更合适，请直接指出，我来改。
- 使用前提：需本机运行青简桌面客户端（qingagent.com，MIT），已在条目描述中注明。
- 仓库 Apache-2.0，npm 包 `dsh-qingagent`（latest 0.1.46），`lib/` 构建产物已入库，github 安装免构建，无 install 期 lifecycle 脚本。
- 本地已跑 `node scripts/validate.mjs`：校验通过（307 条，无格式错误、无重复）。
