### PR TITLE
feat(ui-themes): add @kubor/dsh-bloom-theme

### DIFF
--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -17,6 +17,7 @@
 - [deepseek-harness-skin](https://github.com/HeiGeAi/deepseek-harness-skin) — 换肤系统：21 套内置皮肤 + 一图生成整套配色 ⭐51
 - [dsh-homepage-skin](https://github.com/yushi-xxh/dsh-homepage-skin) — 给 dsh web 铺上 DeepSeek Harness 首页同款背景：WebGL 流体、点线网格与数字鲸鱼，深浅双主题 · `dsh plugin --profile web add dsh-homepage-skin` ⭐3
 
+- [@kubor/dsh-bloom-theme](https://github.com/webkubor/dsh-bloom-theme) — Bloom for DSH：玻璃 + 莫兰迪主题，9 套 OKLCH 配色（雾蓝 / 朱砂 / 花瓣 / 涟漪 / 鼠尾草 / 暖石 / 青金 / 琥珀 / 极光），明暗自适应；磨砂玻璃面板默认常开；极光变体背景带极光丝带流动动画 · `dsh plugin --profile web add @kubor/dsh-bloom-theme@0.9.0`
 ## 界面增强 / 面板
 
 - [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 侧边栏完整工作台：文件渲染编辑/终端/Git/子代理，支持三方注册 Tab ⭐3157 · `dsh plugin add dsh-better-sidebar`


### PR DESCRIPTION
## 新增条目

在 `plugins/ui-themes.md`「皮肤 / 主题」分类末尾加一行：

```markdown
- [@kubor/dsh-bloom-theme](https://github.com/webkubor/dsh-bloom-theme) — Bloom for DSH：玻璃 + 莫兰迪主题，9 套 OKLCH 配色（雾蓝 / 朱砂 / 花瓣 / 涟漪 / 鼠尾草 / 暖石 / 青金 / 琥珀 / 极光），明暗自适应；磨砂玻璃面板默认常开；极光变体背景带极光丝带流动动画 · `dsh plugin --profile web add @kubor/dsh-bloom-theme@0.9.0`
```

### 为什么这条值得加

- **首发纯主题插件里走"多变体 + 玻璃 + 质感"路线的**：现有 11 条皮肤主题都是「一套色 / 一套背景」，bloom 是少有的「9 套配色变体 + 玻璃面板 + 流动流线」的成品主题。
- **npm 上 `@kubor/dsh-bloom-theme`**：自带 `dsh.bundle` 声明 + `cordis.patch.yml`，`npm run check` 8 组闸门 + `contrast-guard` 18 组 WCAG AA 全过，`files` 白名单齐全——符合 awesome-dsh-plugin 收录门槛。
- **0.9.0 本轮新增**（这次发版更新到 npm latest）：
  - ✨ 新增「极光 Aurora」变体 + 背景层极光丝带流动动画
  - 🐛 修复输入卡片边框双层叠加导致的"粗框" + focus 环 3px→2px
  - 🐛 修复表格列分隔线不可见（hairline → hairline-strong + 表头底色 + 斑马纹）
  - 🐛 抬亮暗色琥珀（bgD 21.9→26%、sfD 29.1→32%）
- **零依赖、零运行时开销**：只注入 CSS 变量 + 顶栏切换器。

### install 命令必须带具体版本号

README 实测踩坑：根因是 pnpm 优先复用 lockfile 里已有的解析结果，`@latest` 被判定为「已满足」而跳过。本插件 `package.json` 写的是 `^0.8.x`，所以新装旧版 0.8.8 的用户 `up @latest` 原地不动，必须写 `@0.9.0`。

### 仓库清单

- 主仓库：`github.com/webkubor/dsh-bloom-theme`
- npm：`@kubor/dsh-bloom-theme@0.9.0` (dist-tags.latest)
- README：含演示截图 + 「动效仅状态反馈」的克制设计哲学
