### PR TITLE
docs: 收录 dsh-memory_rollout（记忆/知识分类）

### DIFF
--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -15,6 +15,7 @@
 - [dsh-llm-wiki](https://github.com/detpecca/dsh-llm-wiki) — 从 agent 管理 LLM-Wiki 知识库（wiki_search/read/stats/ingest 等） ⭐4 · `dsh plugin add @detpecca/dsh-llm-wiki`
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格）沉淀自会话轨迹，带审查门禁与技能热加载 ⭐16 · `dsh plugin add dsh-continual-evolve`
 - [dsh-meow-memory](https://github.com/Phant0Meow/dsh-meow-memory) — 跨会话项目记忆：SQLite 分层存储 + 关键词/语义检索，逐消息命中注入与窗口期整理 ⭐65 · `dsh plugin add github:Phant0Meow/dsh-meow-memory`
+- [dsh-memory_rollout](https://github.com/Bionic-forest/dsh-memory_rollout) — Codex 风格的 DSH 会话持久记忆：一会话一草稿、分层披露、克制被动、幂等整合，跨会话记住事实/偏好/决策并带可核验引用 · `dsh plugin add dsh-memory_rollout`
 
 ## 上下文审计 / 压缩 / 蒸馏
 


### PR DESCRIPTION
新增 DSH 会话记忆插件 **dsh-memory_rollout** 到「记忆 / 知识」分类。

- Codex 风格的 DSH 会话持久记忆：一会话一草稿（rollout_summaries）、分层披露（summary→注册表→草稿/证据）、克制被动、幂等整合，跨会话记住事实/偏好/决策并带可核验引用。
- 已在 npm 发布：`dsh-memory_rollout`（`dsh plugin add dsh-memory_rollout`）。
- 仓库已打 `dsh-plugin` topic，可正常 `dsh plugin add` 安装。