### PR TITLE
Add sofagent to infrastructure-dev (audit/health-check)

### DIFF
--- a/plugins/infrastructure-dev.md
+++ b/plugins/infrastructure-dev.md
@@ -19,6 +19,7 @@
 - [dsh-doctor](https://github.com/asdf17128/dsh-doctor) — profile 健康检查：找 patch 静默破坏的配置/死 patch/工具名冲突 ⭐1
 - [dsh-capability-inspector](https://github.com/tree201/dsh-capability-inspector) — DSH Doctor + 运行时诊断（工具/模型/技能/工作区/会话/插件/MCP 排障） ⭐2 · `dsh plugin add dsh-capability-inspector`
 - [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) — 本机安全审计：配置/插件来源/会话/网络暴露面，只读脱敏报告 ⭐14 · `dsh plugin add @deepseek-ai/dsh-security-audit`
+- [sofagent](https://github.com/KongFangXun/sofagent) — 开源 FDE Harness 约束层：24 条 git diff 审计规则 + 80 个 MCP 工具 + 9 款 cordis-plugin 深度集成，Agent 违规当场拦截 ⭐42
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) — 会话文件帧级扫描诊断（torn/损坏/空会话检测） ⭐9 · `dsh plugin add @deepseek-ai/dsh-session-health`
 - [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — dsh 登录网关（密码门）：远程访问鉴权 + 多用户账号管理，HTTPS/防爆破/审计日志 ⭐40 · `dsh plugin add github:slywalker2006/dsh-passwords`
 


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) to the **基础设施 / 插件管理 / 开发工具 → 健康检查 / 诊断 / 审计** section（placed after `dsh-security-audit`, per `docs/taxonomy.md` boundary for `infrastructure-dev`）.

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent (KongFangXun).

sofagent is an open-source FDE Harness governance layer for DeepSeek Harness agents: 24 git-diff audit rules (17 quick-mode defaults + 7 extension rules) with commit-time interception, an MCP server exposing 80 tools, snapshot rollback, and 9 `cordis-plugin-sofagent-*` plugins that mount directly into the DSH runtime via Cordis. MIT licensed.

Related listings: [awesome-dsh-plugin/awesome-dsh-plugin #4101](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/4101) (merged), [beancookie/awesome-dsh-plugin #137](https://github.com/beancookie/awesome-dsh-plugin/pull/137) (merged), [0xsline/awesome-deepseek-harness #547](https://github.com/0xsline/awesome-deepseek-harness/pull/547).

Single-line addition to `plugins/infrastructure-dev.md` only.
