### PR TITLE
添加 6 个 PerryLink 旗舰插件

### DIFF
--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -34,6 +34,8 @@
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) — 跨 dsh/Codex/Claude/pi/OpenCode 会话的无索引全文搜索 ⭐2
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话 ⭐131 · `dsh plugin add dsh-chat-import`
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) — 迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH ⭐14 · `dsh plugin add dsh-claude-move`
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) — 有界分层、审批门控、可审计的跨会话记忆，支持冻结快照注入 ⭐85 · `dsh plugin add dsh-memento`
+- [dsh-checkpoint-rewind](https://github.com/PerryLink/dsh-checkpoint-rewind) — 会话检查点与倒带：快照会话状态并可回退重放 ⭐14 · `dsh plugin add dsh-checkpoint-rewind`
 
 <!-- nav:start -->
 ---

--- a/plugins/mcp.md
+++ b/plugins/mcp.md
@@ -10,6 +10,7 @@
 - [shadow-vision](https://github.com/WardLu/shadow-vision) — 开源 MCP 视觉 server，给纯文本 LLM 图片理解/OCR/UI 检查 ⭐2
 - [mcp-bridge](https://github.com/WongJingGitt/mcp-bridge) — MCP 浏览器桥接，让网页端 AI 调用 MCP 工具 ⭐35
 - [dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) — BitFun 与 DSH 的 ACP 交互对接 ⭐10 · `dsh plugin add dsh-acp-for-bitfun`
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) — 设置面板管理 MCP 服务器、连接状态与开关 ⭐53 · `dsh plugin add dsh-mcp-panel`
 
 <!-- nav:start -->
 ---

--- a/plugins/workflow-automation.md
+++ b/plugins/workflow-automation.md
@@ -23,6 +23,9 @@
 - [dsh-tiered-approval](https://github.com/Elaina-real/dsh-tiered-approval) — 分层自动审查：静态规则 + LLM 审查 + 人工兜底 ⭐2 · `dsh plugin add dsh-tiered-approval`
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) — 事件流审计面板：观察事件类型/分发模式/计数，帮插件作者理解内部 ⭐1 · `dsh plugin add @dsh-external/dsh-event-auditor`
 - [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) — 自动续传：网络中断后自动发「继续」恢复请求 ⭐59 · `dsh plugin add github:HsiangNianian/dsh-auto-continue`
+- [dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) — 审批链第二模型：只读评审子代理在动作执行前返回结构化 allow/deny 裁决，默认故障关闭 ⭐130 · `dsh plugin add dsh-auto-review`
+- [dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) — 声明式权限规则：按工具/路径/命令门控代理动作 ⭐106 · `dsh plugin add dsh-permission-rules`
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) — 写入前双重校验：需求拷问、红/绿测试证据门、分叉对手评审与交付报告 ⭐13 · `dsh plugin add dsh-doublecheck`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
按 taxonomy 分类新增 6 行：workflow-automation（dsh-auto-review ⭐130 / dsh-permission-rules ⭐106 / dsh-doublecheck ⭐13）、context-memory（dsh-memento ⭐85 / dsh-checkpoint-rewind ⭐14）、mcp（dsh-mcp-panel ⭐53）。均带 dsh plugin add 安装命令与 2026-09-03 实测星数。