### PR TITLE
添加 4 个 PerryLink 插件（dsh-reach / dsh-wechat / dsh-ticktick / dsh-cert-mcp）

### DIFF
--- a/plugins/mcp.md
+++ b/plugins/mcp.md
@@ -10,6 +10,7 @@
 - [shadow-vision](https://github.com/WardLu/shadow-vision) — 开源 MCP 视觉 server，给纯文本 LLM 图片理解/OCR/UI 检查 ⭐2
 - [mcp-bridge](https://github.com/WongJingGitt/mcp-bridge) — MCP 浏览器桥接，让网页端 AI 调用 MCP 工具 ⭐36
 - [dsh-acp-for-bitfun](https://github.com/bobleer/dsh-acp-for-bitfun) — BitFun 与 DSH 的 ACP 交互对接 ⭐10 · `dsh plugin add dsh-acp-for-bitfun`
+- [dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp) — DSH 插件认证注册表 MCP 服务器
 
 <!-- nav:start -->
 ---

--- a/plugins/notifications-channels.md
+++ b/plugins/notifications-channels.md
@@ -11,6 +11,8 @@
 - [dsh-lark-bridge](https://github.com/imetn/dsh-lark-bridge) — 双向飞书控制器 ⭐7 · `dsh plugin add dsh-lark-bridge`
 - [dsh-onlyne](https://github.com/dbydd/dsh-onlyne) — IM 网关：从 dsh 会话收发 QQ/微信/飞书/Telegram 消息 ⭐2
 - [dsh-im](https://github.com/xmanrui/dsh-im) — 一个设置入口统一接入飞书/微信/钉钉/企业微信/QQ/Slack/Telegram/Discord/WhatsApp 机器人，支持扫码、Manifest 或凭据绑定 · `npx -y github:xmanrui/dsh-im install` ⭐1107
+- [dsh-reach](https://github.com/PerryLink/dsh-reach) — 把 DSH 审批/提问卡推送到 IM（先微信）并在聊天中作答，带逐通道安全与开放推送服务 · `dsh plugin add dsh-reach`
+- [dsh-wechat](https://github.com/PerryLink/dsh-wechat) — 微信私聊桥接 DSH：文本、图片、文件、音视频双向传输
 
 ## 通知
 

--- a/plugins/tools.md
+++ b/plugins/tools.md
@@ -33,6 +33,7 @@
 - [dsh-port-guard](https://github.com/PangYiMing/dsh-port-guard) — 端口占用处置（复用/切换/精确 kill） ⭐1 · `dsh plugin add dsh-port-guard`
 - [dsh-scout](https://github.com/omdsh-dev/dsh-scout) — 只读环境探测：运行环境/版本/资源/端口/服务/硬件/工作区 ⭐2 · `dsh plugin add @deepseek-ai/dsh-tool-scout`
 - [dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) — 事务化强力卸载引擎：每个破坏性动作走 validate/preview/execute/undo 四段式 + Saga 回滚，WAL 崩溃自恢复、hash chain 审计链、硬链接去重、贝叶斯先知推演成功率；回收区代替物理删除（可恢复） ⭐3 · `dsh plugin add github:beijingwahw/dsh-nuke-plugin`
+- [dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) — TickTick（滴答清单）任务桥：会话页头部任务面板 + 官方 MCP 端点代理工具 · `dsh plugin add @perrylink/dsh-ticktick`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
按 [docs/taxonomy.md](docs/taxonomy.md) 14 类边界新增 4 个条目：

- `plugins/notifications-channels.md`（📡 通知 / 渠道 / 远程 · IM 机器人 / 渠道）：
  - [dsh-reach](https://github.com/PerryLink/dsh-reach) — 把 DSH 审批/提问卡推送到 IM（先微信）并在聊天中作答，带逐通道安全与开放推送服务
  - [dsh-wechat](https://github.com/PerryLink/dsh-wechat) — 微信私聊桥接 DSH：文本、图片、文件、音视频双向传输
- `plugins/tools.md`（🛠️ 工具类）：
  - [dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) — TickTick（滴答清单）任务桥：会话页头部任务面板 + 官方 MCP 端点代理工具
- `plugins/mcp.md`（🔌 MCP 接入）：
  - [dsh-cert-mcp](https://github.com/PerryLink/dsh-cert-mcp) — DSH 插件认证注册表 MCP 服务器

- [x] 插件未在目录中重复收录（先在对应分类文件里搜一下）
- [x] 分类符合 [docs/taxonomy.md](docs/taxonomy.md) 的边界
- [x] 描述一句话说清「解决什么问题」
- [x] 链接为公开 GitHub 仓库

### 变更类型
- [x] 新增插件

### 说明
4 个插件均为公开 GitHub 仓库、有 README 与可运行代码；dsh-reach / dsh-ticktick 可 `dsh plugin add` 安装（npm 实测存在），dsh-cert-mcp 为 stdio MCP 服务器（`npx @perrylink/dsh-cert-mcp`）。