### PR TITLE
新增 dsh-session-manager（归档会话管理：恢复/彻底删除/墓碑延迟清理）

### DIFF
--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -34,6 +34,7 @@
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) — 跨 dsh/Codex/Claude/pi/OpenCode 会话的无索引全文搜索 ⭐2
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话 ⭐135 · `dsh plugin add dsh-chat-import`
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) — 迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH ⭐15 · `dsh plugin add dsh-claude-move`
+- [dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager) — 已归档会话管理：设置页列出/恢复/彻底删除（直接物理删除，无备份层），会话菜单红色删除项、/sessions 命令与三个 agent 工具；已打开的会话也能立即删除（墓碑隐藏，重启后自动清理） ⭐0 · `dsh plugin add github:SunshineR04/dsh-session-manager`
 
 <!-- nav:start -->
 ---

--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -34,7 +34,7 @@
 - [dsh-session-search](https://github.com/Tieboyh/dsh-session-search) — 跨 dsh/Codex/Claude/pi/OpenCode 会话的无索引全文搜索 ⭐2
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话 ⭐135 · `dsh plugin add dsh-chat-import`
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) — 迁移 Claude Code 会话/记忆/技能/CLAUDE.md 到 DSH ⭐15 · `dsh plugin add dsh-claude-move`
-- [dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager) — 已归档会话管理：设置页列出/恢复/彻底删除（直接物理删除，无备份层），会话菜单红色删除项、/sessions 命令与三个 agent 工具；已打开的会话也能立即删除（墓碑隐藏，重启后自动清理） ⭐0 · `dsh plugin add github:SunshineR04/dsh-session-manager`
+- [dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager) — 已归档会话管理：设置页列出/恢复/彻底删除（直接物理删除，无备份层），会话菜单红色删除项；已打开的会话也能立即删除（墓碑隐藏，重启后自动清理） ⭐0 · `dsh plugin add github:SunshineR04/dsh-session-manager`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
在 `plugins/context-memory.md` 的「会话控制 / 回退」小节新增一条：

`dsh-session-manager`（[SunshineR04/dsh-session-manager](https://github.com/SunshineR04/dsh-session-manager)）
- 设置页列出已归档会话：恢复 / 彻底删除（直接物理删除，无备份层）
- 会话三点菜单红色删除项、`/sessions` 斜杠命令、三个 agent 工具
- 差异点：已打开的会话也能立即删除——登记与文件当场清除，残留内存副本以归档集墓碑隐藏，重启后自动清理

已声明 `dsh.bundle` manifest + `cordis.patch.yml`，仓库含 20 个单测/渲染测试，v0.2.2，MIT。