### PR TITLE
Add dsh-amphoreus (skills) — δ-me13 seat workspaces for DeepSeek Harness

### DIFF
--- a/plugins/skills.md
+++ b/plugins/skills.md
@@ -20,6 +20,7 @@
 - [forkprobe](https://github.com/Jayden-X-L/forkprobe) — 同一任务对比多个 skill 并选出最优 ⭐71 · `dsh plugin add github:Jayden-X-L/forkprobe`
 
 <!-- nav:start -->
+- [dsh-amphoreus](https://github.com/xi-kari/dsh-amphoreus) — 把 δ-me13（翁法罗斯）13 张角色技能卡变成席位工作区：逐席主题与壁纸、首轮注入技能卡、对话表情、每席记忆与预设、Alt+数字切席、派发与移交总览画布；技能套件从本地目录读取，不随插件打包 ⭐0 · `dsh plugin add dsh-amphoreus`
 ---
 ← [上一类: 🛠️ 工具类 Tools](tools.md) · [返回目录](../README.md) · [下一类: 🔌 MCP 接入](mcp.md) →
 <!-- nav:end -->

--- a/web/data.js
+++ b/web/data.js
@@ -1,12 +1,12 @@
 // 由 scripts/gen-web-data.mjs 自动生成，请勿手改。
 window.__DSH_DATA__ = {
-  "generatedAt": "2026-09-05T22:25:04.546Z",
+  "generatedAt": "2026-09-06T01:27:23.438Z",
   "source": "scripts/gen-web-data.mjs",
   "stats": {
-    "plugins": 306,
+    "plugins": 307,
     "categories": 14,
-    "withInstall": 234,
-    "withStars": 305
+    "withInstall": 235,
+    "withStars": 306
   },
   "categories": [
     {
@@ -591,6 +591,16 @@ window.__DSH_DATA__ = {
       "description": "同一任务对比多个 skill 并选出最优",
       "stars": 71,
       "install": "dsh plugin add github:Jayden-X-L/forkprobe",
+      "category": "skills"
+    },
+    {
+      "name": "dsh-amphoreus",
+      "url": "https://github.com/xi-kari/dsh-amphoreus",
+      "owner": "xi-kari",
+      "repo": "dsh-amphoreus",
+      "description": "把 δ-me13（翁法罗斯）13 张角色技能卡变成席位工作区：逐席主题与壁纸、首轮注入技能卡、对话表情、每席记忆与预设、Alt+数字切席、派发与移交总览画布；技能套件从本地目录读取，不随插件打包",
+      "stars": 0,
+      "install": "dsh plugin add dsh-amphoreus",
       "category": "skills"
     },
     {


### PR DESCRIPTION
One line appended to `plugins/skills.md` (regenerated `web/data.js` via `scripts/gen-web-data.mjs`).

- Repo: https://github.com/xi-kari/dsh-amphoreus (MIT, topic `dsh-plugin`), npm `dsh-amphoreus@0.3.0`.
- What it does: gives the 13 δ-me13 (Amphoreus) role skill cards their own seat workspaces in DSH — per-seat theme/wallpaper, first-turn skill injection, chat stickers, per-seat memory and presets, Alt+digit switching, and an overview canvas for dispatch/handoff. The skill suite is read from a local directory and is not bundled.
- Category: `skills` felt closest (it exists to host a SKILL.md suite); `ui-themes` or `agent-orchestration` also fit — re-file as you see best.
- Install: `dsh plugin --profile web add dsh-amphoreus@0.3.0`.