### PR TITLE
docs: add dsh-backup to infrastructure-dev

### DIFF
--- a/plugins/infrastructure-dev.md
+++ b/plugins/infrastructure-dev.md
@@ -21,6 +21,7 @@
 - [dsh-security-audit](https://github.com/omdsh-dev/dsh-security-audit) — 本机安全审计：配置/插件来源/会话/网络暴露面，只读脱敏报告 ⭐14 · `dsh plugin add @deepseek-ai/dsh-security-audit`
 - [dsh-session-health](https://github.com/omdsh-dev/dsh-session-health) — 会话文件帧级扫描诊断（torn/损坏/空会话检测） ⭐9 · `dsh plugin add @deepseek-ai/dsh-session-health`
 - [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — dsh 登录网关（密码门）：远程访问鉴权 + 多用户账号管理，HTTPS/防爆破/审计日志 ⭐46 · `dsh plugin add github:slywalker2006/dsh-passwords`
+- [dsh-backup](https://github.com/xiaoyuyu6420/dsh-backup) — 一键备份与恢复 DSH 用户数据：定时备份、分级保留、doctor 从备份定点修复会话日志、宿主起不来也能用的进程外救援台、凭据脱敏 ⭐17 · `dsh plugin add @xiaoyuyu6420/dsh-backup`
 
 ## 运行时 / 沙箱 / 遥测 / hook
 


### PR DESCRIPTION
按 [CONTRIBUTING](https://github.com/kejixiaoliang/awesome-dsh-plugins/blob/main/CONTRIBUTING.md) 在 `plugins/infrastructure-dev.md` 的「健康检查 / 诊断 / 审计」小节追加一条：

- [dsh-backup](https://github.com/xiaoyuyu6420/dsh-backup) — 一键备份与恢复 DSH 用户数据（npm 包 `@xiaoyuyu6420/dsh-backup`，`dsh plugin add` 可装）

收录理由：
- 是 dsh 专属 Cordis 插件，公开仓库、有 README 与可运行代码，npm 持续发版（当前 0.11.2）
- 与本小节的会话健康类插件（dsh-session-health 等）互补：它从「备份/恢复」侧兜底——`/backup doctor` 从已知良好备份定点修复损坏会话日志，另有宿主起不来也能用的进程外救援台、定时备份与凭据脱敏
- 本人即插件作者