### PR TITLE
新增 yindf/taskfold（上下文折叠 → context-memory）

### DIFF
--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -23,6 +23,7 @@
 - [distill](https://github.com/LoserFox/distill) — 自动对话蒸馏：后台 subagent 反省 + 技能 create/update ⭐24 · `dsh plugin add @loserfox/distill`
 - [dsh-auto-compact](https://github.com/wangxiang0605qvq/dsh-auto-compact) — compact_now 工具，回合结束自动压缩上下文 ⭐1
 - [dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：展示模型上下文窗口的构成与演化 ⭐1307 · `dsh plugin add dsh-context`
+- [taskfold](https://github.com/yindf/taskfold) — 把已完成的 agent 工作折叠成一条带标题的摘要，长会话保持可读、请求更省；每次折叠的原始内容可随时原样读回 · `dsh plugin add dsh-taskfold`
 
 ## 会话控制 / 回退
 


### PR DESCRIPTION
## 插件

- 仓库：https://github.com/yindf/taskfold
- 分类：context-memory（上下文 / 记忆）
- npm：dsh-taskfold（安装：dsh plugin add dsh-taskfold）
- 协议：MIT

## 说明

长会话上下文折叠插件：	ask_begin 开一个命名任务，	ask_end 关闭它并把整个 span 折成一条带标题的摘要，list_folds 列出全部折叠，old_recall 按需把任意折叠的原始内容原样读回（写入本会话目录下的 JSONL）。折叠只改写历史中段，稳定前缀保持缓存友好。

实测：一次真实会话（411 个模型步骤、26 次折叠）总 prompt token 142,654,308 → 52,127,098（-63.5%），峰值上下文窗口占用 59.5% → 20.7%；该数字来自单次会话与单一任务形态，节省的主要是 cache 读。

## 改动

仅在 plugins/context-memory.md 的「上下文审计 / 压缩 / 蒸馏」小节末尾追加一行。