### PR TITLE
Add dsh-remote-dsh (远程 / 集成 / 分享)

### DIFF
--- a/data/descriptions-en.json
+++ b/data/descriptions-en.json
@@ -535,5 +535,6 @@
  "phant0meow/dsh-meow-smooth": "Mobile-first UX polish for the DSH Web UI (composer auto-fold, phone enter-as-newline, compact sidebar/header, zoom lock) plus task/permission/question notifications (Web Push / Bark webhook) with zero dsh changes.",
  "exoticknight/dsh-labnana": "Labnana image generation plugin: text-to-image / image-to-image / precise editing for NanoBanana Pro, GPT-Image-2, Wan2.7 and Seedream, with in-chat image cards and credit estimate.",
  "fancr-code/dsh-plugin-usage-meter": "API usage/cost/balance dashboard: pill usage bar with peak/off-peak labels, per-model stacked bar chart by day / last 7 days, model distribution, budget alerts and a cross-session ledger.",
- "fancr-code/dsh-tray-launcher": "Windows tray launcher: runs dsh web without a window, right-click tray to switch icons (Liangzu / whale-girl / DeepSeek / custom); quitting quits all."
+ "fancr-code/dsh-tray-launcher": "Windows tray launcher: runs dsh web without a window, right-click tray to switch icons (Liangzu / whale-girl / DeepSeek / custom); quitting quits all.",
+ "hutao562/dsh-remote-dsh": "Adds a row at the top of the sidebar that switches the whole Web GUI to another DSH host reached over a loopback port, with that host's session state on the row (running, unread activity, or waiting for your answer)."
 }

--- a/plugins/notifications-channels.md
+++ b/plugins/notifications-channels.md
@@ -30,6 +30,7 @@
 - [dsh-open-in-vscode](https://github.com/omdsh-dev/dsh-open-in-vscode) — 从 Web GUI 一键在 VS Code 中打开工作区目录 ⭐53 · `dsh plugin add dsh-open-in-vscode`
 - [dsh-share](https://github.com/hellodigua/dsh-share) — 一键分享你的对话 ⭐35 · `dsh plugin add @dsh-external/dsh-share`
 - [dsh-conversation-share](https://github.com/bill9109/dsh-conversation-share) — 分享任意段落的对话 ⭐3 · `dsh plugin add @bill9109/dsh-conversation-share`
+- [dsh-remote-dsh](https://github.com/hutao562/dsh-remote-dsh) — 在侧边栏顶部加一行，点击后整页切换成另一台 DSH 主机的 Web GUI（通过回环端口访问），并在该行显示那台主机的会话状态（运行中、有新活动、正等你回答） · `dsh plugin --profile web add dsh-remote-dsh`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
## 新增插件：dsh-remote-dsh

- 仓库：https://github.com/hutao562/dsh-remote-dsh
- 安装：`dsh plugin --profile web add dsh-remote-dsh`

**功能**：在侧边栏顶部加一行，点击后整页切换成另一台 DSH 主机的 Web GUI（通过回环端口访问），并在该行显示那台主机的会话状态（运行中、有新活动、正等你回答）。

### 分类说明

放在 `plugins/notifications-channels.md` 的「远程 / 集成 / 分享」小节。14 类里没有单独的「远程访问」分类，本插件的核心能力是访问另一台 DSH 主机（回环端口），与已有的 `dsh-ssh` 同属远程访问；侧边栏那一行只是入口 UI，因此没有放进「Web UI / 皮肤 / 主题」。如果维护者认为 `ui-themes.md` 更合适，我可以改。

### 已遵循本仓库提交规范

- 先搜索目录确认未重复收录
- 条目格式与分类文件一致：`- [插件名](仓库) — 一句话描述`，可选安装命令写在末尾
- 按 CONTRIBUTING「新条目追加到分类末尾即可」处理，未改动其他条目、未重排
- 同时补上 `data/descriptions-en.json` 里对应的英文描述，保证 EN/中文 README 一致（README.md / README.zh.md 由 sync CI 生成，未手动改动）
- 本地已运行 `node scripts/validate.mjs`：校验通过，307 条，无格式错误、无重复

### 事实

- `package.json` 声明 `dsh.bundle`，仓库内含已提交的 `cordis.patch.yml`
- 带 `dsh-plugin` / `dsh` / `deepseek-harness` topics
- MIT 许可；无构建步骤；已发布到 npm（0.1.1）
