### PR TITLE
新增 zuoyunlai/lunheng-article-pipeline-dsh（深度长文写作流水线 → agent-orchestration）

### DIFF
--- a/plugins/agent-orchestration.md
+++ b/plugins/agent-orchestration.md
@@ -12,6 +12,7 @@
 - [dsh-plugin-yet-another-subagent](https://github.com/HuanLinOTO/dsh-plugin-yet-another-subagent) — 可配置子代理 profiles + 实时工具调用/token 显示 + 子会话跳转 ⭐15 · `dsh plugin add @huanlin/dsh-plugin-yet-another-subagent`
 - [dsh-a2a](https://github.com/dpskh/dsh-a2a) — Agent2Agent 网状互联 ⚠️ dsh-external，公开性待核实 ⭐10
 - [dsh-devices](https://github.com/polaris-smart/dsh-devices) — 去中心化多设备舰队：mDNS 同网发现 + 密钥配对 + SSH 跨网直连 + SFTP 文件传输，dsh 会话内自动注册 6 个 fleet 工具（零 npm 依赖） ⭐6 · `dsh plugin add dsh-devices`
+- [lunheng-article-pipeline-dsh](https://github.com/zuoyunlai/lunheng-article-pipeline-dsh) — 论衡：主控调度 + 9 个独立角色（文献/数据/案例检索、分析、写作、批判、审计、终检、同行评审）的深度长文写作流水线，跨 6 阶段，含 4 个人在环节点、三角验证、M 门 23 项机械终检、G0-G14 独立审计与审稿评分/期刊匹配 ⭐4 · `dsh plugin add lunheng-article-pipeline`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
新增一条到 `plugins/agent-orchestration.md`（只改这一个文件）。

`zuoyunlai/lunheng-article-pipeline-dsh` —— 深度长文写作流水线，以 DSH bundle 分发（`package.json#dsh.bundle.patch` → `cordis.patch.yml`，另带 `main` 入口 `lib/index.js` 经 `ctx.skills.register` 注册技能），仓库已带 `dsh-plugin` topic，npm 已发布 → `dsh plugin add lunheng-article-pipeline` 可直接装。

描述只写包里实际有的东西：主控调度 + 9 个独立角色（文献/数据/案例检索、分析、写作、批判、审计、终检、同行评审）跨 6 阶段，4 个人在环节点、三角验证、M 门 23 项机械终检（M-Form 11 + M-Exist 10 + M-Integrity 2）、G0-G14 独立审计、审稿评分与期刊匹配。无宣传词。

按文件既有格式带上 `⭐4` 与安装命令；条目按星数排序，故追加在列表末尾（`dsh-devices` ⭐6 之后）、导航注释块之前。
