### PR TITLE
添加 3 个 PerryLink 插件（auto-review / permission-rules / memento）

### DIFF
--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -15,6 +15,7 @@
 - [dsh-llm-wiki](https://github.com/detpecca/dsh-llm-wiki) — 从 agent 管理 LLM-Wiki 知识库（wiki_search/read/stats/ingest 等） ⭐3 · `dsh plugin add @detpecca/dsh-llm-wiki`
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格）沉淀自会话轨迹，带审查门禁与技能热加载 ⭐19 · `dsh plugin add dsh-continual-evolve`
 - [dsh-meow-memory](https://github.com/Phant0Meow/dsh-meow-memory) — 跨会话项目记忆：SQLite 分层存储 + 关键词/语义检索，逐消息命中注入与窗口期整理 ⭐91 · `dsh plugin add github:Phant0Meow/dsh-meow-memory`
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) — 有界、分层、审批门、可审计的跨会话记忆：ctx.memory 服务 + 零依赖 SQLite + memory 工具 + 冻结快照注入 ⭐85（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-memento`
 
 ## 上下文审计 / 压缩 / 蒸馏
 

--- a/plugins/context-memory.md
+++ b/plugins/context-memory.md
@@ -15,7 +15,7 @@
 - [dsh-llm-wiki](https://github.com/detpecca/dsh-llm-wiki) — 从 agent 管理 LLM-Wiki 知识库（wiki_search/read/stats/ingest 等） ⭐3 · `dsh plugin add @detpecca/dsh-llm-wiki`
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — 持续自进化：版本化、可审计、可回滚的 harness 状态（提示词/记忆/技能/子代理规格）沉淀自会话轨迹，带审查门禁与技能热加载 ⭐19 · `dsh plugin add dsh-continual-evolve`
 - [dsh-meow-memory](https://github.com/Phant0Meow/dsh-meow-memory) — 跨会话项目记忆：SQLite 分层存储 + 关键词/语义检索，逐消息命中注入与窗口期整理 ⭐91 · `dsh plugin add github:Phant0Meow/dsh-meow-memory`
-- [dsh-memento](https://github.com/PerryLink/dsh-memento) — 有界、分层、审批门、可审计的跨会话记忆：ctx.memory 服务 + 零依赖 SQLite + memory 工具 + 冻结快照注入 ⭐85（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-memento`
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) — 有界、分层、审批门、可审计的跨会话记忆：ctx.memory 服务 + 零依赖 SQLite + memory 工具 + 冻结快照注入 ⭐88（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-memento`
 
 ## 上下文审计 / 压缩 / 蒸馏
 

--- a/plugins/infrastructure-dev.md
+++ b/plugins/infrastructure-dev.md
@@ -35,6 +35,7 @@
 - [dsh-plugin-graph](https://github.com/erduotong/dsh-plugin-graph) — 插件关系图谱可视化 ⭐1 · `dsh plugin add dsh-plugin-graph`
 - [dsh-dev-actions](https://github.com/skitse/dsh-dev-actions) — Agent 提议的可复用开发命令，转为侧栏动作 ⭐1 · `dsh plugin add dsh-dev-actions`
 - [dsh-tool-policy](https://github.com/Drifter-yh/dsh-tool-policy) — 声明式默认拒绝的工具策略 ⭐3 · `dsh plugin add dsh-tool-policy`
+- [dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) — Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则在 tools/pre-execute 瀑布匹配工具名/参数/工作区路径/agent 身份，会话日志审计 + 干跑 + 热重载 ⭐106（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-permission-rules`
 - [dsh-openai-codex-auth](https://github.com/yoke233/dsh-openai-codex-auth) — OpenAI Codex OAuth 登录与用量卡 ⭐12 · `dsh plugin add dsh-openai-codex-auth`
 
 ## 分发 / 运维 / 迁移

--- a/plugins/infrastructure-dev.md
+++ b/plugins/infrastructure-dev.md
@@ -35,7 +35,7 @@
 - [dsh-plugin-graph](https://github.com/erduotong/dsh-plugin-graph) — 插件关系图谱可视化 ⭐1 · `dsh plugin add dsh-plugin-graph`
 - [dsh-dev-actions](https://github.com/skitse/dsh-dev-actions) — Agent 提议的可复用开发命令，转为侧栏动作 ⭐1 · `dsh plugin add dsh-dev-actions`
 - [dsh-tool-policy](https://github.com/Drifter-yh/dsh-tool-policy) — 声明式默认拒绝的工具策略 ⭐3 · `dsh plugin add dsh-tool-policy`
-- [dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) — Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则在 tools/pre-execute 瀑布匹配工具名/参数/工作区路径/agent 身份，会话日志审计 + 干跑 + 热重载 ⭐106（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-permission-rules`
+- [dsh-permission-rules](https://github.com/PerryLink/dsh-permission-rules) — Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则在 tools/pre-execute 瀑布匹配工具名/参数/工作区路径/agent 身份，会话日志审计 + 干跑 + 热重载 ⭐114（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-permission-rules`
 - [dsh-openai-codex-auth](https://github.com/yoke233/dsh-openai-codex-auth) — OpenAI Codex OAuth 登录与用量卡 ⭐12 · `dsh plugin add dsh-openai-codex-auth`
 
 ## 分发 / 运维 / 迁移

--- a/plugins/workflow-automation.md
+++ b/plugins/workflow-automation.md
@@ -23,6 +23,7 @@
 - [dsh-tiered-approval](https://github.com/Elaina-real/dsh-tiered-approval) — 分层自动审查：静态规则 + LLM 审查 + 人工兜底 ⭐1 · `dsh plugin add dsh-tiered-approval`
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) — 事件流审计面板：观察事件类型/分发模式/计数，帮插件作者理解内部 · `dsh plugin add @dsh-external/dsh-event-auditor`
 - [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) — 自动续传：网络中断后自动发「继续」恢复请求 ⭐92 · `dsh plugin add github:HsiangNianian/dsh-auto-continue`
+- [dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) — 审批链上的第二模型自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，默认 fail-closed，全程会话日志可审计 ⭐130（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-auto-review`
 
 <!-- nav:start -->
 ---

--- a/plugins/workflow-automation.md
+++ b/plugins/workflow-automation.md
@@ -23,7 +23,7 @@
 - [dsh-tiered-approval](https://github.com/Elaina-real/dsh-tiered-approval) — 分层自动审查：静态规则 + LLM 审查 + 人工兜底 ⭐1 · `dsh plugin add dsh-tiered-approval`
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) — 事件流审计面板：观察事件类型/分发模式/计数，帮插件作者理解内部 · `dsh plugin add @dsh-external/dsh-event-auditor`
 - [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) — 自动续传：网络中断后自动发「继续」恢复请求 ⭐92 · `dsh plugin add github:HsiangNianian/dsh-auto-continue`
-- [dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) — 审批链上的第二模型自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，默认 fail-closed，全程会话日志可审计 ⭐130（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-auto-review`
+- [dsh-auto-review](https://github.com/PerryLink/dsh-auto-review) — 审批链上的第二模型自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，默认 fail-closed，全程会话日志可审计 ⭐164（2026-09-03 实测，提交日复核） · `dsh plugin add github:PerryLink/dsh-auto-review`
 
 <!-- nav:start -->
 ---


### PR DESCRIPTION
按 #30 的拆分建议与 issue 讨论结论，本 PR 提交 3 个插件（1–3 条/PR）。

| 插件 | 分类文件 | 解决什么问题 | 可安装性 |
|---|---|---|---|
| dsh-auto-review | workflow-automation | 审批链上的第二模型自动审查（allow/deny + 理由，fail-closed） | dsh.bundle.patch ✓，github: 安装，CI 绿 |
| dsh-permission-rules | infrastructure-dev | 声明式 allow/deny/ask 权限规则（tools/pre-execute 瀑布） | dsh.bundle.patch ✓，github: 安装，CI 绿 |
| dsh-memento | context-memory | 有界、分层、审批门、可审计的跨会话记忆 | dsh.bundle.patch ✓，github: 安装，CI 绿 |

- 公开 GitHub 仓库 ✓、README ✓、可运行代码 ✓（收录标准 YES 三要件）。
- ⭐ 为实测值并注明日期（提交前再复核一次）。
- 只改 plugins/*.md 三个文件；web/data.js 为 gen-web-data.mjs 生成物，未手改。
- 描述一句话「解决什么问题」，无营销词。

本次仅 3 个，遵循拆分建议，见 #84。

**生成物预览（合并后 gen-web-data.mjs 将产出，供核对，勿手改）**

```js
{ name: "dsh-auto-review", url: "https://github.com/PerryLink/dsh-auto-review", owner: "PerryLink", repo: "dsh-auto-review", description: "审批链上的第二模型自动审查：只读审查子代理返回带理由的 allow/deny 结构化裁决，默认 fail-closed，全程会话日志可审计", stars: 130, install: "dsh plugin add github:PerryLink/dsh-auto-review", category: "workflow-automation" },
{ name: "dsh-permission-rules", url: "https://github.com/PerryLink/dsh-permission-rules", owner: "PerryLink", repo: "dsh-permission-rules", description: "Claude Code 风格声明式权限规则：按序 allow/deny/ask YAML 规则在 tools/pre-execute 瀑布匹配工具名/参数/工作区路径/agent 身份，会话日志审计 + 干跑 + 热重载", stars: 106, install: "dsh plugin add github:PerryLink/dsh-permission-rules", category: "infrastructure-dev" },
{ name: "dsh-memento", url: "https://github.com/PerryLink/dsh-memento", owner: "PerryLink", repo: "dsh-memento", description: "有界、分层、审批门、可审计的跨会话记忆：ctx.memory 服务 + 零依赖 SQLite + memory 工具 + 冻结快照注入", stars: 85, install: "dsh plugin add github:PerryLink/dsh-memento", category: "context-memory" }
```
