### PR TITLE
Add hmr-BH/dsh-round-rightclick

### DIFF
--- a/plugins/ui-themes.md
+++ b/plugins/ui-themes.md
@@ -48,6 +48,7 @@
 - [dsh-what-changed](https://github.com/sjh9714/dsh-what-changed) — 会话顶栏一屏看完整会话改动，列出 Agent 写过的每个文件与逐处改动，被权限拒绝的写入单独计数不算改动 · `dsh plugin --profile web add dsh-what-changed` ⭐2
 - [dsh-easyrewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) — DSH Web 用户消息气泡内联编辑与撤回：惰性提交、无痕替换、版本翻页器、草稿自动备份、三语 i18n ⭐108 · `dsh plugin add dsh-easyrewrite`
 - [dsh-meow-smooth](https://github.com/Phant0Meow/dsh-meow-smooth) — 手机优先的 DSH 前端体验优化：输入框失焦自动折叠、手机回车换行、侧边栏/顶部栏压缩、设置页适配、禁缩放回弹，外加长任务完成/权限申请/提问通知（Web Push/Bark webhook） ⭐43 · `dsh plugin add meow-smooth`
+- [dsh-round-rightclick](https://github.com/hmr-BH/dsh-round-rightclick) — 在 DSH Web GUI 的对话轮次上提供径向右键菜单：从指定轮次分叉新会话、中断正在运行的生成、复制工作目录路径、复制会话 ID、在文件管理器中打开工作目录、导出会话日志为 ZIP
 
 ## 生成式 UI / 组件
 


### PR DESCRIPTION
这个插件在 DSH Web GUI 的对话轮次上加入一个径向右键菜单，六项操作分别是：从选中的轮次分叉出新会话、中断正在运行的生成、复制工作目录路径、复制会话 ID、在文件管理器中打开工作目录、把会话日志导出为 ZIP。仓库的 `package.json` 声明了 `dsh.bundle.patch`（指向 `./cordis.patch.yml`）与 `dsh.client`（`platform: web`），并已发布到 npm：`dsh-round-rightclick@0.1.0`。
